### PR TITLE
Improve manga library and add-manga flow

### DIFF
--- a/riidaa/CoreModel.xcdatamodeld/.xccurrentversion
+++ b/riidaa/CoreModel.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>CoreModelV3.xcdatamodel</string>
+	<string>CoreModelV4.xcdatamodel</string>
 </dict>
 </plist>

--- a/riidaa/CoreModel.xcdatamodeld/CoreModelV4.xcdatamodel/contents
+++ b/riidaa/CoreModel.xcdatamodeld/CoreModelV4.xcdatamodel/contents
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24D81" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="MangaModel" representedClassName=".MangaModel" syncable="YES">
+        <attribute name="anilist_id" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="cover" optional="YES" attributeType="Binary" defaultValueString="" allowsExternalBinaryDataStorage="YES" allowsCloudEncryption="YES"/>
+        <attribute name="added_at" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="title" attributeType="String"/>
+        <relationship name="volumes" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="MangaVolumeModel" inverseName="manga" inverseEntity="MangaVolumeModel"/>
+    </entity>
+    <entity name="MangaPageModel" representedClassName=".MangaPageModel" syncable="YES">
+        <attribute name="height" attributeType="Integer 32" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="image" attributeType="String" allowsExternalBinaryDataStorage="YES"/>
+        <attribute name="number" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="read_at" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="width" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="boxes" toMany="YES" deletionRule="Cascade" destinationEntity="PageBoxModel" inverseName="page" inverseEntity="PageBoxModel"/>
+        <relationship name="volume" maxCount="1" deletionRule="Nullify" destinationEntity="MangaVolumeModel" inverseName="pages" inverseEntity="MangaVolumeModel"/>
+    </entity>
+    <entity name="MangaVolumeModel" representedClassName=".MangaVolumeModel" syncable="YES">
+        <attribute name="lastReadPage" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="number" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="manga" maxCount="1" deletionRule="Nullify" destinationEntity="MangaModel" inverseName="volumes" inverseEntity="MangaModel"/>
+        <relationship name="pages" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="MangaPageModel" inverseName="volume" inverseEntity="MangaPageModel"/>
+    </entity>
+    <entity name="PageBoxModel" representedClassName=".PageBoxModel" syncable="YES">
+        <attribute name="height" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="rotation" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="text" attributeType="String" defaultValueString=""/>
+        <attribute name="width" attributeType="Integer 32" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="x" attributeType="Integer 32" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="y" attributeType="Integer 32" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <relationship name="page" maxCount="1" deletionRule="Nullify" destinationEntity="MangaPageModel" inverseName="boxes" inverseEntity="MangaPageModel"/>
+    </entity>
+</model>

--- a/riidaa/Models/Manga/MangaModel+CoreDataProperties.swift
+++ b/riidaa/Models/Manga/MangaModel+CoreDataProperties.swift
@@ -21,6 +21,7 @@ extension MangaModel {
     @NSManaged public var id: UUID
     @NSManaged public var anilist_id: NSNumber?
     @NSManaged public var title: String
+    @NSManaged public var added_at: NSDate?
     @NSManaged public var volumes: NSOrderedSet
 
 }

--- a/riidaa/Views/Mangas/MangaAddResultView.swift
+++ b/riidaa/Views/Mangas/MangaAddResultView.swift
@@ -35,13 +35,40 @@ struct MangaAddResultView : View {
     var body: some View {
         ScrollView {
             LazyVGrid(columns: columns, spacing: 8) {
+                Button {
+                    createManga(cover: nil)
+                } label: {
+                    VStack(alignment: .leading, spacing: 0) {
+                        Image(systemName: "plus")
+                            .scaleEffect(2)
+                            .foregroundColor(.gray)
+                            .frame(width: 110, height: 170)
+                            .background(Color(.systemGray3))
+                            .cornerRadius(10)
+
+                        VStack() {
+                            Text("Create without cover")
+                                .font(.callout)
+                                .foregroundColor(.primary)
+                                .lineLimit(2)
+                                .truncationMode(.tail)
+                            Spacer()
+                        }
+                        .frame(height: 49)
+                        .padding(.top, 7)
+                        .padding([.leading, .trailing], 1)
+                    }
+                    .frame(height: 226)
+                }
+                .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
                 PhotosPicker(
                     selection: $customImage,
                     matching: .images,
                     photoLibrary: .shared()
                 ) {
                     VStack(alignment: .leading,spacing: 0) {
-                        Image(systemName: "book")
+                        Image(systemName: "photo")
                             .scaleEffect(2)
                             .foregroundColor(.gray)
                             .frame(width: 110, height: 170)
@@ -50,7 +77,7 @@ struct MangaAddResultView : View {
                         
                         
                         VStack() {
-                            Text("Create title")
+                            Text("Create with a photo")
                                 .font(.callout)
                                 .foregroundColor(.primary)
                                 .lineLimit(2)
@@ -68,6 +95,7 @@ struct MangaAddResultView : View {
                             context: self.moc
                         )
                         newManga.id = UUID()
+                        newManga.added_at = NSDate()
                         newManga.anilist_id = manga.id as NSNumber
                         newManga.title = manga.title.wrappedValue
                         newManga.downloadCover(url: manga.wrappedValue.coverImage, completion: { result in
@@ -124,18 +152,24 @@ struct MangaAddResultView : View {
         }
         .onChange(of: customImage) { value in
             Task {
-                if let value = value {
-                    if let data = try? await value.loadTransferable(type: Data.self) {
-                        let newManga = MangaModel(context: self.moc)
-                        newManga.id = UUID()
-                        newManga.title = self.title
-                        newManga.cover = data
-                        CoreDataManager.shared.saveContext()
-                        dismiss()
-                    }
+                if let value = value, let data = try? await value.loadTransferable(type: Data.self) {
+                    createManga(cover: data)
                 }
             }
         }
+    }
+
+    /// Creates a manga from the typed title. A nil cover shows a placeholder image
+    private func createManga(cover: Data?) {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let newManga = MangaModel(context: self.moc)
+        newManga.id = UUID()
+                        newManga.added_at = NSDate()
+        newManga.title = trimmed
+        newManga.cover = cover
+        CoreDataManager.shared.saveContext()
+        dismiss()
     }
     
     
@@ -144,6 +178,7 @@ struct MangaAddResultView : View {
     private func addManga(manga: MangaResultModel) {
         let newManga = MangaModel(context: self.moc)
         newManga.id = UUID()
+                        newManga.added_at = NSDate()
         newManga.anilist_id = manga.id as NSNumber
         newManga.title = manga.title
         newManga.downloadCover(url: manga.coverImage) { result in

--- a/riidaa/Views/Mangas/MangaAddView.swift
+++ b/riidaa/Views/Mangas/MangaAddView.swift
@@ -14,6 +14,7 @@ struct MangaAddView: View {
     @State var searchMangasList: [MangaResultModel] = []
     @Environment(\.dismiss) var dismiss
     @State var isSearching = false
+    @State var searchMessage: String? = nil
     @FocusState private var isTextFieldFocused: Bool
     @Environment(\.managedObjectContext) var moc
     
@@ -22,7 +23,32 @@ struct MangaAddView: View {
     
     var body: some View {
         VStack {
-            TextField("Manga title...", text: $mangaTitle, onCommit: searchMangas)
+            HStack {
+                Text("Add a manga")
+                    .font(.headline)
+                Spacer()
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityLabel("Close")
+            }
+            .padding(.horizontal)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Search AniList by title, then pick the right match. Its cover and details are used for your library — you add volume files afterwards.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal)
+            .padding(.bottom, 10)
+
+            HStack(spacing: 8) {
+                TextField("Search AniList by title...", text: $mangaTitle, onCommit: searchMangas)
                 .padding(10)
                 .background(Color(.secondarySystemBackground))
                 .cornerRadius(10)
@@ -42,8 +68,15 @@ struct MangaAddView: View {
                         .animation(.spring(response: 0.3, dampingFraction: 0.6), value: mangaTitle)
                     }
                 )
-                .padding(.horizontal)
                 .focused($isTextFieldFocused)
+                .submitLabel(.search)
+                .onSubmit(searchMangas)
+
+                Button("Search", action: searchMangas)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(mangaTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSearching)
+            }
+            .padding(.horizontal)
             
             ScrollView {
                 if isSearching {
@@ -57,13 +90,26 @@ struct MangaAddView: View {
                             .padding(.top, 20)
                     }
                     .frame(maxWidth: .infinity, minHeight: 150)
+                } else if let searchMessage = searchMessage {
+                    VStack {
+                        Image(systemName: "exclamationmark.circle")
+                            .scaleEffect(2)
+                            .foregroundColor(.gray)
+                        Text(searchMessage)
+                            .font(.headline)
+                            .foregroundColor(.gray)
+                            .multilineTextAlignment(.center)
+                            .padding(.top, 20)
+                            .padding(.horizontal)
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 150)
                 } else if searchMangasList.isEmpty && mangaTitle == "" {
                     VStack {
                         Image(systemName: "book.closed")
                         //                            .font(.largeTitle)
                             .scaleEffect(2)
                             .foregroundColor(.gray)
-                        Text("Start searching for a manga")
+                        Text("Search AniList for a title")
                             .font(.headline)
                             .foregroundColor(.gray)
                             .padding(.top, 20)
@@ -82,29 +128,46 @@ struct MangaAddView: View {
         .background(Color(.systemBackground))
     }
     
+    private func applyResults(_ results: [MangaResultModel], matchesFound: Int) {
+        self.searchMangasList = results
+        if !results.isEmpty {
+            self.searchMessage = nil
+        } else if matchesFound > 0 {
+            self.searchMessage = "Every match is already in your library."
+        } else {
+            self.searchMessage = "No manga found for “\(mangaTitle)”."
+        }
+    }
+
+    private func searchFailed(_ error: Error) {
+        self.searchMangasList = []
+        self.searchMessage = "Search failed: \(error.localizedDescription)"
+    }
+
     func searchMangas() {
+        guard !mangaTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        self.searchMessage = nil
         self.isSearching = true
 
         if settings.adult {
             Network.shared.apollo.fetch(query: MangaSearchQueryAdultQuery(page: 1, search: .some(mangaTitle))) { result in
                 switch result {
                 case .success(let data):
-                    if let medias = data.data?.page?.media {
-                        let mangaIDs = MangaModel.fetchMangaAnilistIDs(moc: moc)
-                        
-                        self.searchMangasList = medias.compactMap({ media in
-                            guard let id = media?.id, !mangaIDs.contains(Int64(id)) else {
-                                return nil
-                            }
-                            return MangaResultModel(
-                                id: Int64(id),
-                                title: media?.title?.native ?? "",
-                                coverImage: media?.coverImage?.large ?? ""
-                            )
-                        })
-                    }
+                    let medias = data.data?.page?.media ?? []
+                    let mangaIDs = MangaModel.fetchMangaAnilistIDs(moc: moc)
+                    let results: [MangaResultModel] = medias.compactMap({ media in
+                        guard let id = media?.id, !mangaIDs.contains(Int64(id)) else {
+                            return nil
+                        }
+                        return MangaResultModel(
+                            id: Int64(id),
+                            title: media?.title?.native ?? media?.title?.romaji ?? media?.title?.english ?? "",
+                            coverImage: media?.coverImage?.large ?? ""
+                        )
+                    })
+                    self.applyResults(results, matchesFound: medias.count)
                 case .failure(let err):
-                    print("error: \(err)")
+                    self.searchFailed(err)
                 }
                 self.isSearching = false
             }
@@ -112,22 +175,21 @@ struct MangaAddView: View {
             Network.shared.apollo.fetch(query: MangaSearchQuery(page: 1, search: .some(mangaTitle))) { result in
                 switch result {
                 case .success(let data):
-                    if let medias = data.data?.page?.media {
-                        let mangaIDs = MangaModel.fetchMangaAnilistIDs(moc: moc)
-                        
-                        self.searchMangasList = medias.compactMap({ media in
-                            guard let id = media?.id, !mangaIDs.contains(Int64(id)) else {
-                                return nil
-                            }
-                            return MangaResultModel(
-                                id: Int64(id),
-                                title: media?.title?.native ?? "",
-                                coverImage: media?.coverImage?.large ?? ""
-                            )
-                        })
-                    }
+                    let medias = data.data?.page?.media ?? []
+                    let mangaIDs = MangaModel.fetchMangaAnilistIDs(moc: moc)
+                    let results: [MangaResultModel] = medias.compactMap({ media in
+                        guard let id = media?.id, !mangaIDs.contains(Int64(id)) else {
+                            return nil
+                        }
+                        return MangaResultModel(
+                            id: Int64(id),
+                            title: media?.title?.native ?? media?.title?.romaji ?? media?.title?.english ?? "",
+                            coverImage: media?.coverImage?.large ?? ""
+                        )
+                    })
+                    self.applyResults(results, matchesFound: medias.count)
                 case .failure(let err):
-                    print("error: \(err)")
+                    self.searchFailed(err)
                 }
                 self.isSearching = false
             }

--- a/riidaa/Views/Mangas/MangaListView.swift
+++ b/riidaa/Views/Mangas/MangaListView.swift
@@ -6,6 +6,16 @@
 //
 
 import SwiftUI
+import PhotosUI
+import CoreData
+
+enum MangaSort: String, CaseIterable, Identifiable {
+    case title = "Title"
+    case lastRead = "Last read"
+    case dateAdded = "Date added"
+
+    var id: String { rawValue }
+}
 
 struct MangaListView: View {
     
@@ -17,33 +27,119 @@ struct MangaListView: View {
     @State var showRenameAlert: Bool = false
     @State var mangaEdit: MangaModel? = nil
     @State var newMangaName: String = ""
+
+    @State private var searchText: String = ""
+    @State private var sort: MangaSort = .title
+    @State private var ascending: Bool = true
+    @State private var lastReadByManga: [NSManagedObjectID: Date] = [:]
+
+    @State private var coverTarget: MangaModel? = nil
+    @State private var showCoverPicker: Bool = false
+    @State private var pickedCover: PhotosPickerItem? = nil
+
+    private var visibleMangas: [MangaModel] {
+        let matches = searchText.isEmpty
+            ? Array(mangas)
+            : mangas.filter { $0.title.localizedCaseInsensitiveContains(searchText) }
+        let sorted = matches.sorted { isOrderedBefore($0, $1) }
+        return ascending ? sorted : sorted.reversed()
+    }
+
+    private func isOrderedBefore(_ a: MangaModel, _ b: MangaModel) -> Bool {
+        switch sort {
+        case .title:
+            return a.title.localizedStandardCompare(b.title) == .orderedAscending
+        case .lastRead:
+            return byDate(lastReadByManga[a.objectID], lastReadByManga[b.objectID], a, b)
+        case .dateAdded:
+            return byDate(a.added_at as Date?, b.added_at as Date?, a, b)
+        }
+    }
+
+    private func byDate(_ left: Date?, _ right: Date?, _ a: MangaModel, _ b: MangaModel) -> Bool {
+        switch (left, right) {
+        case let (l?, r?) where l != r: return l > r
+        case (_?, nil): return true
+        case (nil, _?): return false
+        default: return a.title.localizedStandardCompare(b.title) == .orderedAscending
+        }
+    }
+
+    /// Only runs for the sort that needs it
+    private func refreshLastRead() {
+        guard sort == .lastRead, lastReadByManga.isEmpty else { return }
+
+        let request = NSFetchRequest<NSDictionary>(entityName: "MangaPageModel")
+        request.predicate = NSPredicate(format: "read_at != nil")
+        request.resultType = .dictionaryResultType
+        request.propertiesToFetch = ["read_at", "volume.manga"]
+
+        guard let rows = try? moc.fetch(request) else { return }
+        var latest: [NSManagedObjectID: Date] = [:]
+        for row in rows {
+            guard let date = row["read_at"] as? Date,
+                  let manga = row["volume.manga"] as? NSManagedObjectID else { continue }
+            if let seen = latest[manga], seen >= date { continue }
+            latest[manga] = date
+        }
+        lastReadByManga = latest
+    }
     
     var body: some View {
         NavigationStack {
             ScrollView {
-                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
-                    ForEach(mangas) { manga in
-                        MangaCover(
-                            manga: manga,
-                            showRenameAlert: $showRenameAlert,
-                            mangaEdit: $mangaEdit,
-                            newMangaName: $newMangaName
-                        )
-                    }
-                }.padding()
+                if visibleMangas.isEmpty {
+                    emptyState
+                } else {
+                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
+                        ForEach(visibleMangas) { manga in
+                            MangaCover(
+                                manga: manga,
+                                showRenameAlert: $showRenameAlert,
+                                mangaEdit: $mangaEdit,
+                                newMangaName: $newMangaName,
+                                coverTarget: $coverTarget,
+                                showCoverPicker: $showCoverPicker
+                            )
+                        }
+                    }.padding()
+                }
             }.navigationTitle("Mangas")
+                .searchable(text: $searchText, prompt: "Search your library")
                 .toolbar {
-                    Button(action: {
-                        showMangaAddView = true
-                    }) {
-                        Image(systemName: "plus")
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Menu {
+                            Picker("Sort by", selection: $sort) {
+                                ForEach(MangaSort.allCases) { option in
+                                    Text(option.rawValue).tag(option)
+                                }
+                            }
+                            Divider()
+                            Button {
+                                ascending.toggle()
+                            } label: {
+                                Label(
+                                    ascending ? "Ascending" : "Descending",
+                                    systemImage: ascending ? "arrow.up" : "arrow.down"
+                                )
+                            }
+                        } label: {
+                            Image(systemName: "arrow.up.arrow.down")
+                        }
+                    }
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button(action: {
+                            showMangaAddView = true
+                        }) {
+                            Image(systemName: "plus")
+                        }
                     }
                 }
                 .sheet(isPresented: $showMangaAddView) {
                     MangaAddView()
                 }
         }
-        .alert("test", isPresented: $showRenameAlert, actions: {
+        .alert("Rename manga", isPresented: $showRenameAlert, actions: {
             TextField("New manga name", text: $newMangaName)
             Button("Cancel", role: .cancel) {}
             Button {
@@ -56,6 +152,39 @@ struct MangaListView: View {
                 Text("Save")
             }
         })
+        .onAppear { refreshLastRead() }
+        .onChange(of: sort) { _ in refreshLastRead() }
+        .photosPicker(isPresented: $showCoverPicker, selection: $pickedCover, matching: .images)
+        .onChange(of: pickedCover) { item in
+            guard let item = item, let manga = coverTarget else { return }
+            Task {
+                if let data = try? await item.loadTransferable(type: Data.self),
+                   let image = UIImage(data: data) {
+                    manga.setCover(image: image)
+                    CoreDataManager.shared.saveContext()
+                }
+                pickedCover = nil
+                coverTarget = nil
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: searchText.isEmpty ? "books.vertical" : "magnifyingglass")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text(searchText.isEmpty ? "No manga yet" : "No manga matching “\(searchText)”")
+                .font(.headline)
+            if searchText.isEmpty {
+                Text("Tap + to search for a title and add it.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 80)
     }
     
 }
@@ -68,6 +197,8 @@ struct MangaCover : View {
     @Binding var showRenameAlert: Bool
     @Binding var mangaEdit: MangaModel?
     @Binding var newMangaName: String
+    @Binding var coverTarget: MangaModel?
+    @Binding var showCoverPicker: Bool
     
     var body: some View {
         NavigationLink(destination: VolumeListView(manga: manga)) {
@@ -82,13 +213,17 @@ struct MangaCover : View {
                         .frame(width: 110, height: 170)
                         .cornerRadius(10)
                 } else {
-                    Text("failed to load image")
-                        .font(.caption)
-                        .foregroundColor(.primary)
-                    
-                        .padding(.top, 5)
-                        .frame(width: 110, height: 170)
-                        .cornerRadius(10)
+                    VStack(spacing: 6) {
+                        Image(systemName: "book.closed")
+                            .font(.title2)
+                            .foregroundStyle(.secondary)
+                        Text("No cover")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(width: 110, height: 170)
+                    .background(Color(.secondarySystemBackground))
+                    .cornerRadius(10)
                 }
                 
                 
@@ -107,18 +242,24 @@ struct MangaCover : View {
             }
             .frame(height: 226)
             .contextMenu {
-                Button(role: .destructive) {
-                    moc.delete(manga)
-                    CoreDataManager.shared.saveContext()
-                } label: {
-                    Label("Delete manga", systemImage: "trash")
-                }
                 Button {
                     showRenameAlert = true
                     mangaEdit = manga
                     newMangaName = manga.title
                 } label: {
                     Label("Rename manga", systemImage: "pencil")
+                }
+                Button {
+                    coverTarget = manga
+                    showCoverPicker = true
+                } label: {
+                    Label("Change cover", systemImage: "photo")
+                }
+                Button(role: .destructive) {
+                    moc.delete(manga)
+                    CoreDataManager.shared.saveContext()
+                } label: {
+                    Label("Delete manga", systemImage: "trash")
                 }
             }
         }

--- a/riidaa/Views/Mangas/MangaListView.swift
+++ b/riidaa/Views/Mangas/MangaListView.swift
@@ -67,7 +67,7 @@ struct MangaListView: View {
 
     /// Only runs for the sort that needs it
     private func refreshLastRead() {
-        guard sort == .lastRead, lastReadByManga.isEmpty else { return }
+        guard sort == .lastRead else { return }
 
         let request = NSFetchRequest<NSDictionary>(entityName: "MangaPageModel")
         request.predicate = NSPredicate(format: "read_at != nil")
@@ -138,6 +138,8 @@ struct MangaListView: View {
                 .sheet(isPresented: $showMangaAddView) {
                     MangaAddView()
                 }
+                .onAppear { refreshLastRead() }
+                .onChange(of: sort) { _ in refreshLastRead() }
         }
         .alert("Rename manga", isPresented: $showRenameAlert, actions: {
             TextField("New manga name", text: $newMangaName)
@@ -152,8 +154,6 @@ struct MangaListView: View {
                 Text("Save")
             }
         })
-        .onAppear { refreshLastRead() }
-        .onChange(of: sort) { _ in refreshLastRead() }
         .photosPicker(isPresented: $showCoverPicker, selection: $pickedCover, matching: .images)
         .onChange(of: pickedCover) { item in
             guard let item = item, let manga = coverTarget else { return }

--- a/riidaa/Views/Mangas/VolumeListView.swift
+++ b/riidaa/Views/Mangas/VolumeListView.swift
@@ -343,10 +343,21 @@ struct VolumeProcessing: View {
                 EmptyView()
             }
             Text(processingModel.message)
-                .font(.largeTitle)
+                .font(.title2)
                 .multilineTextAlignment(.center)
                 .padding()
-            
+
+            if processingModel.status != ProcessingStatus.STARTED {
+                Button("Done") {
+                    processingModel.status = ProcessingStatus.NOTHING
+                }
+                .font(.headline)
+                .padding(.horizontal, 40)
+                .padding(.vertical, 12)
+                .background(Color.blue)
+                .foregroundColor(.white)
+                .cornerRadius(10)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }


### PR DESCRIPTION
# Description 
A few quality-of-life changes to the library and the add-manga sheet.

**Library**
- Search, and sort by title / last read / date added with an asc-desc toggle
- Change a manga's cover from the context menu
- Empty states for an empty library and for no search results
- Manga without a cover show a placeholder rather than "failed to load image"

**Adding a manga**
- Made it clearer that the search queries AniList, and added a Search button
- Search now reports failures, and says when every match is already in the library
- You can create a manga without picking a cover

**Small fixes**
- Added a Done button to the volume import sheet

Adds an optional `added_at` attribute (CoreData model v4) for the date sort. 
_Note: manga added before this have no date and sort last._