### PR TITLE
Support pitch accent and frequency dictionaries

### DIFF
--- a/riidaa/AppManager.swift
+++ b/riidaa/AppManager.swift
@@ -14,44 +14,112 @@ class AppManager : ObservableObject {
     
     @Published var isLoading = true
     @Published var dictionaries: [DictionaryDB] = []
+
+    @Published var deleting: Set<Int64> = []
+    @Published var purging: PurgeProgress? = nil
+
+    @Published var working: [Int64: DictionaryProgress] = [:]
+    @Published var preparing: DictionaryProgress? = nil
+    @Published var lastError: String? = nil
+    
+    func deleteDictionary(id: Int64) {
+        guard !deleting.contains(id) else { return }
+        deleting.insert(id)
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            try? SQLiteManager.shared.deleteDictionary(dictionaryId: id)
+            DispatchQueue.main.async {
+                self.dictionaries.removeAll { $0.id == id }
+                self.deleting.remove(id)
+            }
+            self.purgeOrphanedEntries()
+        }
+    }
+
+    func purgeOrphanedEntries() {
+        purgeQueue.async {
+            SQLiteManager.shared.purgeOrphanedEntries(progress: { cleared, total in
+                let update = PurgeProgress(cleared: cleared, total: total)
+                DispatchQueue.main.async {
+                    self.purging = update.isFinished ? nil : update
+                }
+            })
+            DispatchQueue.main.async { self.purging = nil }
+        }
+    }
+
+    private let purgeQueue = DispatchQueue(label: "dev.repierre.riidaa.purge", qos: .utility)
+
+    func setProgress(_ progress: DictionaryProgress?, for id: Int64?) {
+        DispatchQueue.main.async {
+            guard let id = id else {
+                self.preparing = progress
+                return
+            }
+            self.preparing = nil
+            if let progress = progress {
+                self.working[id] = progress
+            } else {
+                self.working.removeValue(forKey: id)
+            }
+        }
+    }
+
+    func report(error: String?) {
+        DispatchQueue.main.async {
+            self.lastError = error
+            self.preparing = nil
+        }
+    }
     
     private init() {
-        DispatchQueue.main.async {
-            self.loadDictionaries()
-        }
+        loadDictionaries()
+        discardExtractedDictionaries()
+        purgeOrphanedEntries()
     }
-    
-    func loadDictionaries() {
-        self.isLoading = true
-        
-        do {
-            for row in try SQLiteManager.shared.getDatabase()!.prepare(SQLiteManager.shared.dictionaries) {
-                dictionaries.append(DictionaryDB(
-                    id: row[SQLiteManager.shared.id],
-                    revision: row[SQLiteManager.shared.revision],
-                    title: row[SQLiteManager.shared.title],
-                    sequenced: row[SQLiteManager.shared.sequenced],
-                    format: row[SQLiteManager.shared.format],
-                    author: row[SQLiteManager.shared.author],
-                    isUpdatable: row[SQLiteManager.shared.isUpdatable],
-                    indexUrl: row[SQLiteManager.shared.indexUrl],
-                    downloadUrl: row[SQLiteManager.shared.downloadUrl],
-                    url: row[SQLiteManager.shared.url],
-                    description: row[SQLiteManager.shared.description],
-                    attribution: row[SQLiteManager.shared.attribution],
-                    sourceLanguage: row[SQLiteManager.shared.sourceLanguage],
-                    targetLanguage: row[SQLiteManager.shared.targetLanguage],
-                    frequencyMode: row[SQLiteManager.shared.frequencyMode]
-                ))
+
+    /// Removes leftover extractions
+    private func discardExtractedDictionaries() {
+        let fileManager = FileManager.default
+        guard let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            return
+        }
+        let root = documents.appendingPathComponent("dictionaries")
+
+        guard let leftovers = try? fileManager.contentsOfDirectory(at: root, includingPropertiesForKeys: nil),
+              !leftovers.isEmpty else {
+            return
+        }
+
+        DispatchQueue.global(qos: .utility).async {
+            for leftover in leftovers {
+                try? fileManager.removeItem(at: leftover)
             }
-//            for row in try SQLiteManager.shared.getDatabase()!.prepare(SQLiteManager.shared.terms) {
-//                readings.append(row[SQLiteManager.shared.reading])
-//            }
-        } catch {
-            
         }
-        
-        self.isLoading = false
+    }
+
+    func loadDictionaries() {
+        DispatchQueue.main.async { self.isLoading = true }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let loaded = SQLiteManager.shared.allDictionaries()
+            DispatchQueue.main.async {
+                self.dictionaries = loaded
+                self.isLoading = false
+            }
+        }
     }
     
+}
+
+struct PurgeProgress: Equatable {
+    let cleared: Int
+    let total: Int
+
+    var fraction: Double {
+        guard total > 0 else { return 0 }
+        return min(1, Double(cleared) / Double(total))
+    }
+
+    var isFinished: Bool { cleared >= total }
 }

--- a/riidaa/Models/Dictionary/TermMeta.swift
+++ b/riidaa/Models/Dictionary/TermMeta.swift
@@ -1,0 +1,160 @@
+//
+//  TermMeta.swift
+//  riidaa
+//
+
+import Foundation
+
+public struct PitchAccent: Hashable {
+    public let position: Int
+    public let devoice: [Int]
+
+    public func category(moraCount: Int) -> String {
+        if position == 0 { return "heiban" }
+        if position == 1 { return "atamadaka" }
+        if position >= moraCount { return "odaka" }
+        return "nakadaka"
+    }
+
+    /// Small kana combine with the preceding mora
+    public static func moraCount(of reading: String) -> Int {
+        let combining: Set<Character> = [
+            "ゃ", "ゅ", "ょ", "ぁ", "ぃ", "ぅ", "ぇ", "ぉ", "ゎ",
+            "ャ", "ュ", "ョ", "ァ", "ィ", "ゥ", "ェ", "ォ", "ヮ",
+        ]
+        return reading.filter { !combining.contains($0) }.count
+    }
+}
+
+public struct TermFrequency: Hashable {
+    public let value: Int64?
+    public let display: String
+}
+
+public struct TermMetaDB: Hashable {
+    public enum Content: Hashable {
+        case frequency(TermFrequency)
+        case pitch([PitchAccent])
+    }
+
+    public let term: String
+    public let reading: String
+    let dictionary: DictionaryDB
+    public let content: Content
+
+    public func applies(toReading termReading: String) -> Bool {
+        reading.isEmpty || reading == termReading
+    }
+}
+
+public struct TermMetaParser {
+
+    /// Decodes the `data` element of a `[term, mode, data]` triple, or nil
+    /// doesn't handle and data that doesn't match the spec.
+    public static func parse(mode: String, data: Any) -> (reading: String, content: TermMetaDB.Content)? {
+        switch mode {
+        case "freq":
+            return parseFrequency(data)
+        case "pitch":
+            return parsePitch(data)
+        default:
+            return nil
+        }
+    }
+
+    private static func parseFrequency(_ data: Any) -> (reading: String, content: TermMetaDB.Content)? {
+        if let map = data as? [String: Any], let reading = map["reading"] as? String {
+            guard let inner = map["frequency"], let frequency = frequencyValue(inner) else { return nil }
+            return (reading, .frequency(frequency))
+        }
+        guard let frequency = frequencyValue(data) else { return nil }
+        return ("", .frequency(frequency))
+    }
+
+    private static func frequencyValue(_ data: Any) -> TermFrequency? {
+        if let number = data as? Int64 {
+            return TermFrequency(value: number, display: String(number))
+        }
+        if let number = data as? Int {
+            return TermFrequency(value: Int64(number), display: String(number))
+        }
+        if let number = data as? Double {
+            return TermFrequency(value: Int64(number), display: String(Int64(number)))
+        }
+        if let text = data as? String {
+            return TermFrequency(value: Int64(text), display: text)
+        }
+        if let map = data as? [String: Any] {
+            let value = (map["value"] as? Int).map(Int64.init) ?? (map["value"] as? Int64)
+            let display = map["displayValue"] as? String ?? value.map(String.init)
+            guard let display = display else { return nil }
+            return TermFrequency(value: value, display: display)
+        }
+        return nil
+    }
+
+    private static func parsePitch(_ data: Any) -> (reading: String, content: TermMetaDB.Content)? {
+        guard let map = data as? [String: Any],
+              let reading = map["reading"] as? String,
+              let pitches = map["pitches"] as? [[String: Any]] else {
+            return nil
+        }
+        let accents: [PitchAccent] = pitches.compactMap { pitch in
+            guard let position = pitch["position"] as? Int else { return nil }
+            return PitchAccent(position: position, devoice: pitch["devoice"] as? [Int] ?? [])
+        }
+        guard !accents.isEmpty else { return nil }
+        return (reading, .pitch(accents))
+    }
+
+}
+
+/// Collapses the metadata applying to one term into the strings the lookup panel and the Anki
+/// export both read, so the two can't drift apart.
+public struct TermMetaSummary {
+    let pitches: [PitchAccent]
+    let frequencies: [(dictionary: String, frequency: TermFrequency)]
+    let reading: String
+
+    init(meta: [TermMetaDB], reading: String) {
+        self.reading = reading
+        let applicable = meta.filter { $0.applies(toReading: reading) }
+        self.pitches = applicable.flatMap { entry -> [PitchAccent] in
+            if case .pitch(let accents) = entry.content { return accents }
+            return []
+        }
+        self.frequencies = applicable.compactMap { entry in
+            if case .frequency(let frequency) = entry.content {
+                return (entry.dictionary.title, frequency)
+            }
+            return nil
+        }
+    }
+
+    public var isEmpty: Bool { pitches.isEmpty && frequencies.isEmpty }
+
+    public var pitchPositions: [String] {
+        deduplicated(pitches.map { "[\($0.position)]" })
+    }
+
+    public var pitchCategories: [String] {
+        let mora = PitchAccent.moraCount(of: reading)
+        return deduplicated(pitches.map { $0.category(moraCount: mora) })
+    }
+
+    /// Deduplicated: metadata is looked up under both the term and its reading, and a rating
+    /// filed under both comes back twice.
+    public var frequencyLabels: [String] {
+        deduplicated(frequencies.map { "\($0.dictionary): \($0.frequency.display)" })
+    }
+
+    /// Lower means more common.
+    public var frequencySortValue: Int64? {
+        frequencies.compactMap { $0.frequency.value }.min()
+    }
+
+    private func deduplicated(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        return values.filter { seen.insert($0).inserted }
+    }
+}

--- a/riidaa/SQLiteManager.swift
+++ b/riidaa/SQLiteManager.swift
@@ -16,6 +16,7 @@ class SQLiteManager {
     // Table Definitions
     let dictionaries = Table("dictionaries")
     let terms = Table("terms")
+    let termMeta = Table("term_meta")
 
     // Dictionary
     let id = Expression<Int64>("id")
@@ -45,6 +46,18 @@ class SQLiteManager {
     let termTags = SQLite.Expression<String>("termTags")
     let dictionaryId = SQLite.Expression<Int64>("dictionaryId")
     let exportedToAnki = SQLite.Expression<Bool>("exportedToAnki")
+
+    // Term metadata
+    let metaMode = SQLite.Expression<String>("mode")
+    let metaReading = SQLite.Expression<String>("metaReading")
+    let metaData = SQLite.Expression<Data>("data")
+
+    /// Every statement runs here
+    private let access = DispatchQueue(label: "dev.repierre.riidaa.sqlite")
+
+    private func perform<T>(_ work: () throws -> T) rethrows -> T {
+        try access.sync(execute: work)
+    }
 
     private init() {
         do {
@@ -85,24 +98,135 @@ class SQLiteManager {
             })
             try db?.run(terms.createIndex(term, ifNotExists: true))
             try db?.run(terms.createIndex(reading, ifNotExists: true))
-            try db?.run(terms.addColumn(exportedToAnki, defaultValue: false))
+            try db?.run(terms.createIndex(dictionaryId, ifNotExists: true))
+
+            try db?.run(termMeta.create(ifNotExists: true) { t in
+                t.column(term)
+                t.column(metaReading)
+                t.column(metaMode)
+                t.column(metaData)
+                t.column(dictionaryId)
+                t.foreignKey(dictionaryId, references: dictionaries, id, delete: .cascade)
+            })
+            try db?.run(termMeta.createIndex(term, ifNotExists: true))
+            try db?.run(termMeta.createIndex(dictionaryId, ifNotExists: true))
         } catch {
             print("Database setup failed: \(error)")
+        }
+
+        do {
+            try db?.run(terms.addColumn(exportedToAnki, defaultValue: false))
+        } catch {
+            // Column already present.
+        }
+
+        do {
+            try db?.run("PRAGMA wal_checkpoint(TRUNCATE)")
+        } catch {
+            print("checkpoint failed: \(error)")
         }
     }
 
     func getDatabase() -> Connection? {
         return db
     }
+
+    func allDictionaries() -> [DictionaryDB] {
+        perform {
+            guard let db = db else { return [] }
+            var loaded: [DictionaryDB] = []
+            do {
+                for row in try db.prepare(dictionaries) {
+                    loaded.append(DictionaryDB(
+                        id: row[id],
+                        revision: row[revision],
+                        title: row[title],
+                        sequenced: row[sequenced],
+                        format: row[format],
+                        author: row[author],
+                        isUpdatable: row[isUpdatable],
+                        indexUrl: row[indexUrl],
+                        downloadUrl: row[downloadUrl],
+                        url: row[url],
+                        description: row[description],
+                        attribution: row[attribution],
+                        sourceLanguage: row[sourceLanguage],
+                        targetLanguage: row[targetLanguage],
+                        frequencyMode: row[frequencyMode]
+                    ))
+                }
+            } catch {
+                print("Failed to load dictionaries: \(error)")
+            }
+            return loaded
+        }
+    }
     
+    /// Removes the dictionary itself and nothing else.
     func deleteDictionary(dictionaryId: Int64) throws {
-        let terms = terms.filter(self.dictionaryId == dictionaryId)
-        try db!.run(terms.delete())
-        let dics = dictionaries.filter(id == dictionaryId)
-        try db!.run(dics.delete())
+        try perform {
+            guard let db = db else { return }
+            try db.run(dictionaries.filter(id == dictionaryId).delete())
+        }
+    }
+
+    /// Clears rows belonging to dictionaries that no longer exist, a batch at a time.
+    func purgeOrphanedEntries(
+        batchSize: Int = 750,
+        shouldContinue: () -> Bool = { true },
+        progress: ((_ cleared: Int, _ total: Int) -> Void)? = nil
+    ) {
+        let orphanCondition = "dictionaryId NOT IN (SELECT id FROM dictionaries)"
+        let tables = ["terms", "term_meta"]
+
+        let total: Int = perform {
+            guard let db = db else { return 0 }
+            return tables.reduce(0) { running, table in
+                let raw = try? db.scalar("SELECT count(*) FROM \(table) WHERE \(orphanCondition)")
+                guard let value = raw as? Int64 else { return running }
+                return running + Int(value)
+            }
+        }
+        guard total > 0 else { return }
+
+        var cleared = 0
+        var finished = false
+        progress?(cleared, total)
+
+        for table in tables {
+            let statement = "DELETE FROM \(table) WHERE rowid IN (SELECT rowid FROM \(table) WHERE \(orphanCondition) LIMIT ?)"
+            while shouldContinue() {
+                let removed: Int = perform {
+                    guard let db = db else { return 0 }
+                    do {
+                        try db.run(statement, batchSize)
+                        return db.changes
+                    } catch {
+                        print("purge failed: \(error)")
+                        return 0
+                    }
+                }
+                if removed == 0 { break }
+                cleared += removed
+                progress?(cleared, total)
+                finished = cleared >= total
+                // Let anything waiting on the database in ahead of the next batch.
+                Thread.sleep(forTimeInterval: 0.02)
+            }
+        }
+
+        if finished {
+            progress?(total, total)
+        }
     }
     
     func insertDictionary(revision: String, title: String, sequenced: Bool, format: Int, author: String?, isUpdatable: Bool, indexUrl: String?, downloadUrl: String?, url: String?, description: String?, attribution: String?, sourceLanguage: String?, targetLanguage: String?, frequencyMode: String?) -> DictionaryDB? {
+        perform {
+            insertDictionaryLocked(revision: revision, title: title, sequenced: sequenced, format: format, author: author, isUpdatable: isUpdatable, indexUrl: indexUrl, downloadUrl: downloadUrl, url: url, description: description, attribution: attribution, sourceLanguage: sourceLanguage, targetLanguage: targetLanguage, frequencyMode: frequencyMode)
+        }
+    }
+
+    private func insertDictionaryLocked(revision: String, title: String, sequenced: Bool, format: Int, author: String?, isUpdatable: Bool, indexUrl: String?, downloadUrl: String?, url: String?, description: String?, attribution: String?, sourceLanguage: String?, targetLanguage: String?, frequencyMode: String?) -> DictionaryDB? {
         let insertQuery = dictionaries.insert(
             self.title <- title,
             self.revision <- revision,
@@ -131,6 +255,33 @@ class SQLiteManager {
         return nil
     }
     
+    /// SQLite rejects a statement carrying more than SQLITE_MAX_VARIABLE_NUMBER bind
+    /// parameters — 32766 since 3.32. `insertMany` puts every row into a single statement, so a
+    /// large bank has to be split
+    private static let maxBindVariables = 32766
+
+    private func insert(into table: Table, setters: [[Setter]], columnsPerRow: Int) -> Int64? {
+        guard !setters.isEmpty else { return 0 }
+
+        let chunkSize = max(1, SQLiteManager.maxBindVariables / max(1, columnsPerRow))
+        return perform {
+            guard let db = db else { return nil }
+            var inserted: Int64 = 0
+            do {
+                try db.transaction {
+                    for start in stride(from: 0, to: setters.count, by: chunkSize) {
+                        let chunk = Array(setters[start..<min(start + chunkSize, setters.count)])
+                        inserted = try db.run(table.insertMany(or: .ignore, chunk))
+                    }
+                }
+                return inserted
+            } catch {
+                print("error: \(error)")
+                return nil
+            }
+        }
+    }
+
     func insertTerms(termsInsert: [TermInsertion]) -> Int64? {
         var setters: [[Setter]] = []
         for term in termsInsert {
@@ -146,16 +297,63 @@ class SQLiteManager {
                 self.dictionaryId <- term.dictionaryId
             ])
         }
-        let insertQuery = terms.insertMany(or: .ignore, setters)
+        return insert(into: terms, setters: setters, columnsPerRow: 9)
+    }
+    
+    func insertTermMeta(metaInsert: [TermMetaInsertion]) -> Int64? {
+        var setters: [[Setter]] = []
+        for meta in metaInsert {
+            setters.append([
+                self.term <- meta.term,
+                self.metaReading <- meta.reading,
+                self.metaMode <- meta.mode,
+                self.metaData <- meta.data,
+                self.dictionaryId <- meta.dictionaryId
+            ])
+        }
+        return insert(into: termMeta, setters: setters, columnsPerRow: 5)
+    }
+
+    func findTermMeta(texts: [String]) -> [TermMetaDB] {
+        perform { findTermMetaLocked(texts: texts) }
+    }
+
+    private func findTermMetaLocked(texts: [String]) -> [TermMetaDB] {
+        var result: [TermMetaDB] = []
+        guard let db = db else { return result }
+
+        let query = termMeta.filter(texts.contains(self.term))
         do {
-            return try db?.run(insertQuery)
+            for row in try db.prepare(query) {
+                guard let dictionary = AppManager.shared.dictionaries.first(where: {
+                    $0.id == row[self.dictionaryId]
+                }) else {
+                    continue
+                }
+                guard let raw = try? JSONSerialization.jsonObject(with: row[metaData]),
+                      let parsed = TermMetaParser.parse(mode: row[metaMode], data: raw) else {
+                    continue
+                }
+                result.append(
+                    TermMetaDB(
+                        term: row[self.term],
+                        reading: parsed.reading,
+                        dictionary: dictionary,
+                        content: parsed.content
+                    )
+                )
+            }
         } catch {
             print("error: \(error)")
         }
-        return nil
+        return result
     }
-    
+
     func findTerms(texts: [String]) -> [TermDB] {
+        perform { findTermsLocked(texts: texts) }
+    }
+
+    private func findTermsLocked(texts: [String]) -> [TermDB] {
         var result: [TermDB] = []
         
         guard let db = db else { return result }
@@ -199,6 +397,14 @@ class SQLiteManager {
         
         return result
     }
+}
+
+public struct TermMetaInsertion {
+    let term: String
+    let reading: String
+    let mode: String
+    let data: Data
+    let dictionaryId: Int64
 }
 
 public struct TermInsertion {

--- a/riidaa/Views/Settings/DictionariesView.swift
+++ b/riidaa/Views/Settings/DictionariesView.swift
@@ -12,19 +12,47 @@ struct DictionariesView: View {
     
     @EnvironmentObject var appManager: AppManager
     @State private var isPickingDictionary = false
-    @State private var processingStatus = ProcessingStatus.NOTHING
-    @State private var processingMessage: String = "Processing dictionary..."
-    @State private var processingProgress: Int = 0
-    @State private var processingProgressMax: Int = 0
-    
-    private var dismissDisabled: Bool {
-        return processingStatus == ProcessingStatus.STARTED
-    }
     
     var body: some View {
         ScrollView {
-            ForEach($appManager.dictionaries) { dictionary in
-                DictionaryView(dictionary: dictionary.wrappedValue)
+            if let preparing = appManager.preparing {
+                HStack(spacing: 10) {
+                    ProgressView()
+                    Text(preparing.message)
+                        .font(.subheadline)
+                    Spacer()
+                }
+                .padding()
+                .background(Color(.systemGray6))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                .padding(.top, 8)
+            }
+
+            if let purging = appManager.purging {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Clearing deleted dictionary")
+                            .font(.subheadline)
+                        Spacer()
+                        Text("\(Int(purging.fraction * 100))%")
+                            .font(.subheadline.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                    ProgressView(value: purging.fraction)
+                    Text("\((purging.total - purging.cleared).formatted()) entries left. Lookups keep working while this finishes.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding()
+                .background(Color(.systemGray6))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                .padding(.top, 8)
+            }
+
+            ForEach(appManager.dictionaries) { dictionary in
+                DictionaryView(dictionary: dictionary, onUpdate: updateDictionary)
             }
         }
         .navigationTitle("Dictionaries")
@@ -36,10 +64,6 @@ struct DictionariesView: View {
             }
         }
         .fileImporter(isPresented: $isPickingDictionary, allowedContentTypes: [.zip]) { result in
-            self.processingMessage = "Processing dictionary..."
-            self.processingStatus = ProcessingStatus.STARTED
-            self.processingProgress = 0
-            self.processingProgressMax = 0
             switch result {
             case .success(let file):
                 processZipFile(path: file)
@@ -47,66 +71,91 @@ struct DictionariesView: View {
                 print("error while picking dictionary file: \(error)")
             }
         }
-        .sheet(
-            isPresented: .init(get: {
-                return self.processingStatus != ProcessingStatus.NOTHING
-            }, set: { _ in }),
-            onDismiss: {
-                if self.processingStatus != ProcessingStatus.STARTED {
-                    self.processingStatus = ProcessingStatus.NOTHING
+        .alert(
+            "Dictionary error",
+            isPresented: Binding(
+                get: { appManager.lastError != nil },
+                set: { shown in if !shown { appManager.lastError = nil } }
+            ),
+            actions: { Button("OK", role: .cancel) {} },
+            message: { Text(appManager.lastError ?? "") }
+        )
+    }
+
+    /// Downloads `downloadUrl` and re-imports it, replacing the existing copy.
+    func updateDictionary(_ dictionary: DictionaryDB) {
+        guard let downloadUrl = dictionary.downloadUrl, let url = URL(string: downloadUrl) else {
+            appManager.report(error: "This dictionary does not publish a download link.")
+            return
+        }
+
+        let replacing = dictionary.id
+        appManager.setProgress(DictionaryProgress(message: "Downloading…", value: 0, total: 0), for: replacing)
+
+        Task {
+            do {
+                let (temporary, _) = try await URLSession.shared.download(from: url)
+                // The importer keys off the extension, and a download has none.
+                let archive = temporary.deletingPathExtension().appendingPathExtension("zip")
+                try? FileManager.default.removeItem(at: archive)
+                try FileManager.default.moveItem(at: temporary, to: archive)
+
+                await MainActor.run {
+                    self.processZipFile(path: archive, securityScoped: false, replacing: replacing)
                 }
+            } catch {
+                appManager.setProgress(nil, for: replacing)
+                appManager.report(error: "Download failed: \(error.localizedDescription)")
             }
-        ) {
-            VStack{
-                VStack(spacing: 40) {
-                    switch processingStatus {
-                    case .STARTED:
-                        CircularProgressView(progress: self.processingProgress, progressMax: self.processingProgressMax)
-                            .frame(width: 150, height: 150)
-//                        Text("\(processingProgress) / \(processingProgressMax)")
-                        
-                    case .FINISHED:
-                        Image(systemName: "checkmark")
-                            .scaleEffect(4)
-                            .frame(width: 150, height: 150)
-                    case .ERROR:
-                        Image(systemName: "xmark")
-                            .scaleEffect(4)
-                            .frame(width: 150, height: 150)
-                    case .NOTHING:
-                        EmptyView()
-                    }
-                    Text(processingMessage)
-                        .font(.largeTitle)
-                        .multilineTextAlignment(.center)
-                        .padding()
-                    
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
-            .interactiveDismissDisabled(dismissDisabled)
         }
     }
-    
-    func processZipFile(path: URL) {
+
+    func processZipFile(path: URL, securityScoped: Bool = true, replacing: Int64? = nil) {
+        // Snapshot taken here
+        let installedSnapshot = appManager.dictionaries
         DispatchQueue.global(qos: .userInitiated).async {
             let fileManager = FileManager.default
             let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("dictionaries")
             let dicDirectory = documents.appendingPathComponent(UUID().uuidString)
-            
+
+            // Progress goes to AppManager, which outlives this screen.
+            var done = 0
+            var total = 0
+            var reportingId: Int64? = replacing
+            func report(_ message: String) {
+                appManager.setProgress(
+                    DictionaryProgress(message: message, value: done, total: total),
+                    for: reportingId
+                )
+            }
+
+            // Nothing reads these again once they are in SQLite; jitendex unpacks to 500 MB.
+            defer {
+                try? fileManager.removeItem(at: dicDirectory)
+                if !securityScoped {
+                    // riidaa downloaded this one, so it owns the file too.
+                    try? fileManager.removeItem(at: path)
+                }
+            }
+
             do {
-                if !path.startAccessingSecurityScopedResource() {
+                let scoped = securityScoped && path.startAccessingSecurityScopedResource()
+                if securityScoped && !scoped {
                     throw NSError(domain: "DictionaryImport", code: 0, userInfo: [NSLocalizedDescriptionKey: "Permission denied"])
                 }
                 defer {
-                    path.stopAccessingSecurityScopedResource()
+                    if scoped {
+                        path.stopAccessingSecurityScopedResource()
+                    }
                 }
                 
+                report("Unpacking…")
                 try fileManager.createDirectory(at: dicDirectory, withIntermediateDirectories: true)
                 try fileManager.unzipItem(at: path, to: dicDirectory)
                 
                 let dicContent = try fileManager.contentsOfDirectory(at: dicDirectory, includingPropertiesForKeys: nil)
-                self.processingProgressMax = (dicContent.count)
+                total = dicContent.count
+                report("Processing dictionary…")
                 
                 guard let fileContent = try? Data(contentsOf: dicDirectory.appendingPathComponent("index.json")) else {
                     throw NSError(domain: "DictionaryImport", code: 1, userInfo: [NSLocalizedDescriptionKey: "Could not find dictionary index.json"])
@@ -132,17 +181,59 @@ struct DictionariesView: View {
                 let sourceLanguage = dicJson["sourceLanguage"] as? String
                 let targetLanguage = dicJson["targetLanguage"] as? String
                 let frequencyMode = dicJson["frequencyMode"] as? String
+
+                let alreadyInstalled = installedSnapshot.first { existing in
+                    if existing.id == replacing { return false }
+                    if let indexUrl = indexUrl, let other = existing.indexUrl, !indexUrl.isEmpty {
+                        return other == indexUrl
+                    }
+                    return existing.title == title
+                }
+                if let existing = alreadyInstalled {
+                    let action = replacing == nil
+                        ? "Use Update on it instead, or delete it first."
+                        : "Delete one of them first."
+                    throw NSError(domain: "DictionaryImport", code: 4, userInfo: [
+                        NSLocalizedDescriptionKey: existing.revision == revision
+                            ? "\(existing.title) is already installed."
+                            : "\(existing.title) is already installed (revision \(existing.revision)). \(action)"
+                    ])
+                }
+
                 
-                guard let dictionary = SQLiteManager.shared.insertDictionary(revision: revision, title: title, sequenced: sequenced ?? false, format: format ?? 3, author: author, isUpdatable: isUpdatable ?? false, indexUrl: indexUrl, downloadUrl: downloadUrl, url: url, description: description, attribution: attribution, sourceLanguage: sourceLanguage, targetLanguage: targetLanguage, frequencyMode: frequencyMode) else {
+                var installed: DictionaryDB? = nil
+                // Any throw past this point must take the row with it, or a half-imported
+                // dictionary stays installed and feeds partial results into every lookup.
+                defer {
+                    if let installed = installed {
+                        try? SQLiteManager.shared.deleteDictionary(dictionaryId: installed.id)
+                        DispatchQueue.main.async {
+                            appManager.dictionaries.removeAll { $0.id == installed.id }
+                        }
+                        appManager.purgeOrphanedEntries()
+                    }
+                }
+
+                let dictionaryOrNil = SQLiteManager.shared.insertDictionary(revision: revision, title: title, sequenced: sequenced ?? false, format: format ?? 3, author: author, isUpdatable: isUpdatable ?? false, indexUrl: indexUrl, downloadUrl: downloadUrl, url: url, description: description, attribution: attribution, sourceLanguage: sourceLanguage, targetLanguage: targetLanguage, frequencyMode: frequencyMode)
+                guard let dictionary = dictionaryOrNil else {
                     throw NSError(domain: "DictionaryImport", code: 2, userInfo: [NSLocalizedDescriptionKey: "Error saving dictionary"])
                 }
-                
-                
-                DispatchQueue.main.async {
-                    self.processingProgress += 1
+                installed = dictionary
+                // An update keeps reporting against the row the user can see
+                if replacing == nil {
+                    reportingId = dictionary.id
+                    DispatchQueue.main.async { appManager.dictionaries.append(dictionary) }
                 }
+                report("Importing…")
                 
                 
+                done += 1
+                report("Processing dictionary…")
+                
+                
+                var importedTerms = 0
+                var importedMeta = 0
+
                 var i = 1
                 while true {
                     
@@ -177,24 +268,85 @@ struct DictionariesView: View {
                         guard SQLiteManager.shared.insertTerms(termsInsert: insertTerms) != nil else {
                             throw NSError(domain: "DictionaryImport", code: 2, userInfo: [NSLocalizedDescriptionKey: "Error saving terms"])
                         }
+                        importedTerms += insertTerms.count
                         
                         i += 1
                         
-                        DispatchQueue.main.async {
-                            self.processingProgress += 1
-                        }
+                        done += 1
+                        report("Processing dictionary…")
                     }
                 }
-                
-                DispatchQueue.main.async {
-                    appManager.dictionaries.append(dictionary)
-                    self.processingProgress = self.processingProgressMax
-                    self.processingMessage = "Dictionary processed."
-                    self.processingStatus = ProcessingStatus.FINISHED
+
+                // Pitch and frequency dictionaries ship no term_bank files at all.
+                var m = 1
+                while true {
+                    let filename = "term_meta_bank_\(m).json"
+                    let filepath = dicDirectory.appending(component: filename)
+
+                    guard let fileContent = try? Data(contentsOf: filepath) else {
+                        break
+                    }
+                    try autoreleasepool {
+                        let metaJson = try? JSONSerialization.jsonObject(with: fileContent)
+                        guard let metaJson = metaJson as? [[Any]] else {
+                            throw NSError(domain: "DictionaryImport", code: 2, userInfo: [NSLocalizedDescriptionKey: "Error decoding term metadata"])
+                        }
+                        let insertMeta: [TermMetaInsertion] = metaJson.compactMap({ t in
+                            guard t.count >= 3,
+                                  let term = t[0] as? String,
+                                  let mode = t[1] as? String,
+                                  let parsed = TermMetaParser.parse(mode: mode, data: t[2]),
+                                  let dataEncoded = try? JSONSerialization.data(withJSONObject: t[2], options: [.fragmentsAllowed])
+                            else {
+                                return nil
+                            }
+                            return TermMetaInsertion(term: term, reading: parsed.reading, mode: mode, data: dataEncoded, dictionaryId: dictionary.id)
+                        })
+                        guard SQLiteManager.shared.insertTermMeta(metaInsert: insertMeta) != nil else {
+                            throw NSError(domain: "DictionaryImport", code: 2, userInfo: [NSLocalizedDescriptionKey: "Error saving term metadata"])
+                        }
+                        importedMeta += insertMeta.count
+
+                        m += 1
+
+                        done += 1
+                        report("Processing dictionary…")
+                    }
                 }
+
+                if i == 1 && m == 1 {
+                    throw NSError(domain: "DictionaryImport", code: 3, userInfo: [NSLocalizedDescriptionKey: "This dictionary contains no term or metadata banks."])
+                }
+                
+                var summary: [String] = []
+                if importedTerms > 0 {
+                    summary.append("\(importedTerms.formatted()) entries")
+                }
+                if importedMeta > 0 {
+                    summary.append("\(importedMeta.formatted()) pitch/frequency entries")
+                }
+                let processedMessage = "Imported \(title)\n\(summary.joined(separator: " and "))."
+
+                // Removed only once the replacement is safely in, so a failed update can't
+                // leave the user with nothing.
+                if let replacing = replacing {
+                    try SQLiteManager.shared.deleteDictionary(dictionaryId: replacing)
+                }
+
+                DispatchQueue.main.async {
+                    if let replacing = replacing {
+                        appManager.dictionaries.removeAll { $0.id == replacing }
+                        appManager.dictionaries.append(dictionary)
+                    }
+                    appManager.setProgress(nil, for: dictionary.id)
+                    appManager.setProgress(nil, for: replacing)
+                }
+                installed = nil
+                print("riidaa: \(processedMessage)")
+                appManager.purgeOrphanedEntries()
             } catch {
-                self.processingStatus = ProcessingStatus.ERROR
-                self.processingMessage = error.localizedDescription
+                appManager.setProgress(nil, for: reportingId)
+                appManager.report(error: error.localizedDescription)
                 return
             }
         }

--- a/riidaa/Views/Settings/DictionaryView.swift
+++ b/riidaa/Views/Settings/DictionaryView.swift
@@ -7,12 +7,26 @@
 
 import SwiftUI
 
+struct DictionaryProgress {
+    let message: String
+    let value: Int
+    let total: Int
+
+    var fraction: Double? {
+        guard total > 0 else { return nil }
+        return min(1, Double(value) / Double(total))
+    }
+}
+
 struct DictionaryView: View {
 
     @ObservedObject var dictionary: DictionaryDB
+    var onUpdate: ((DictionaryDB) -> Void)? = nil
+
     @Environment(\.managedObjectContext) var moc
     @EnvironmentObject var appManager: AppManager
-    @State private var isDeleting = false
+    private var isDeleting: Bool { appManager.deleting.contains(dictionary.id) }
+    private var progress: DictionaryProgress? { appManager.working[dictionary.id] }
 
     var body: some View {
         HStack {
@@ -26,19 +40,35 @@ struct DictionaryView: View {
                     Text("Version: \(dictionary.revision)").font(.subheadline)
                 }
                 Spacer()
-                switch dictionary.hasUpdate {
-                case UpdateState.updateAvailable:
-                    Button("Update") {
-                        print("Updating \(dictionary.title)")
+                if let progress = progress {
+                    VStack(alignment: .trailing, spacing: 4) {
+                        if let fraction = progress.fraction {
+                            ProgressView(value: fraction)
+                                .frame(width: 110)
+                        } else {
+                            ProgressView()
+                                .frame(width: 110)
+                        }
+                        Text(progress.message)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
                     }
-                    .buttonStyle(BorderlessButtonStyle())
-                    .foregroundColor(.blue)
-                case UpdateState.unknown :
-                    ProgressView()
-                        .padding()
-                case UpdateState.upToDate:
-                    Text("Up to date")
+                } else {
+                    switch dictionary.hasUpdate {
+                    case UpdateState.updateAvailable:
+                        Button("Update") {
+                            onUpdate?(dictionary)
+                        }
+                        .buttonStyle(BorderlessButtonStyle())
                         .foregroundColor(.blue)
+                    case UpdateState.unknown :
+                        ProgressView()
+                            .padding()
+                    case UpdateState.upToDate:
+                        Text("Up to date")
+                            .foregroundColor(.blue)
+                    }
                 }
             }
         }
@@ -51,16 +81,7 @@ struct DictionaryView: View {
         }
         .contextMenu {
             Button(role: .destructive) {
-                let dictionaryId = dictionary.id
-                isDeleting = true
-                Task.detached(priority: .utility) {
-                    try? SQLiteManager.shared.deleteDictionary(dictionaryId: dictionaryId)
-                    await MainActor.run {
-                        if let idx = appManager.dictionaries.firstIndex(where: { $0.id == dictionaryId }) {
-                            appManager.dictionaries.remove(at: idx)
-                        }
-                    }
-                }
+                appManager.deleteDictionary(id: dictionary.id)
             } label: {
                 Label("Delete dictionary", systemImage: "trash")
             }

--- a/riidaa/riidaaApp.swift
+++ b/riidaa/riidaaApp.swift
@@ -18,17 +18,54 @@ struct riidaaApp: App {
     
     var body: some Scene {
         WindowGroup {
-            if appManager.isLoading {
-                VStack {
-                    ProgressView()
-                    Text("Loading dictionaries")
+            HomeView()
+                .environment(\.managedObjectContext, CoreController.context)
+                .environmentObject(appManager)
+                .environmentObject(settings)
+                .overlay(alignment: .bottom) {
+                    if appManager.isLoading {
+                        DictionaryLoadingBanner(text: "Loading dictionaries…", fraction: nil)
+                            .padding(.bottom, 60)
+                            .transition(.move(edge: .bottom).combined(with: .opacity))
+                    }
                 }
-            } else {
-                HomeView()
-                    .environment(\.managedObjectContext, CoreController.context)
-                    .environmentObject(appManager)
-                    .environmentObject(settings)
-            }
+                .overlay(alignment: .bottom) {
+                    if !appManager.isLoading, let purging = appManager.purging {
+                        DictionaryLoadingBanner(
+                            text: "Clearing deleted dictionary… \(Int(purging.fraction * 100))%",
+                            fraction: purging.fraction
+                        )
+                        .padding(.bottom, 60)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                    }
+                }
+                .animation(.easeInOut(duration: 0.25), value: appManager.isLoading)
+                .animation(.easeInOut(duration: 0.25), value: appManager.purging)
         }
+    }
+}
+
+struct DictionaryLoadingBanner: View {
+    let text: String
+    var fraction: Double? = nil
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if let fraction = fraction {
+                ProgressView(value: fraction)
+                    .frame(width: 60)
+            } else {
+                ProgressView()
+                    .controlSize(.small)
+            }
+            Text(text)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
+        .background(.thinMaterial, in: Capsule())
+        .shadow(radius: 4, y: 2)
+        .accessibilityLabel(text)
     }
 }

--- a/riidaaTests/TermMetaStorageTests.swift
+++ b/riidaaTests/TermMetaStorageTests.swift
@@ -1,0 +1,120 @@
+//
+//  TermMetaStorageTests.swift
+//  riidaaTests
+//
+
+import Foundation
+import Testing
+@testable import riidaa
+
+/// Exercises the real SQLite layer on the test host. Serialised because every case drives the
+/// shared connection and the shared dictionary list.
+@MainActor
+@Suite(.serialized)
+struct TermMetaStorageTests {
+
+    private func makeDictionary(_ title: String) -> DictionaryDB? {
+        let dictionary = SQLiteManager.shared.insertDictionary(
+            revision: "test", title: title, sequenced: false, format: 3,
+            author: nil, isUpdatable: false, indexUrl: nil, downloadUrl: nil, url: nil,
+            description: nil, attribution: nil, sourceLanguage: nil, targetLanguage: nil,
+            frequencyMode: nil
+        )
+        if let dictionary = dictionary {
+            AppManager.shared.dictionaries.append(dictionary)
+        }
+        return dictionary
+    }
+
+    private func forget(_ dictionary: DictionaryDB) {
+        try? SQLiteManager.shared.deleteDictionary(dictionaryId: dictionary.id)
+        AppManager.shared.dictionaries.removeAll { $0.id == dictionary.id }
+        SQLiteManager.shared.purgeOrphanedEntries()
+    }
+
+    private func blob(_ raw: String) -> Data { raw.data(using: .utf8)! }
+
+    private func remaining(_ dictionary: DictionaryDB) -> Int {
+        let db = SQLiteManager.shared.getDatabase()!
+        let raw = try? db.scalar("SELECT count(*) FROM term_meta WHERE dictionaryId = ?", dictionary.id)
+        return (raw as? Int64).map(Int.init) ?? -1
+    }
+
+    @Test func storesAndReadsBackBothMetadataKinds() throws {
+        guard let dictionary = makeDictionary("RoundTrip") else { Issue.record("no dictionary"); return }
+        defer { forget(dictionary) }
+
+        #expect(SQLiteManager.shared.insertTermMeta(metaInsert: [
+            TermMetaInsertion(term: "夫妻", reading: "ふさい", mode: "freq",
+                              data: blob(#"{"reading":"ふさい","frequency":{"value":6923,"displayValue":"6923"}}"#),
+                              dictionaryId: dictionary.id),
+            TermMetaInsertion(term: "夫妻", reading: "ふさい", mode: "pitch",
+                              data: blob(#"{"reading":"ふさい","pitches":[{"position":1}]}"#),
+                              dictionaryId: dictionary.id),
+            TermMetaInsertion(term: "夫妻", reading: "ふうさい", mode: "freq",
+                              data: blob(#"{"reading":"ふうさい","frequency":1}"#),
+                              dictionaryId: dictionary.id),
+        ]) != nil)
+
+        let found = SQLiteManager.shared.findTermMeta(texts: ["夫妻"]).filter { $0.dictionary.id == dictionary.id }
+        #expect(found.count == 3)
+
+        // The entry for the other reading is filtered out.
+        let summary = TermMetaSummary(meta: found, reading: "ふさい")
+        #expect(summary.frequencyLabels == ["RoundTrip: 6923"])
+        #expect(summary.pitchPositions == ["[1]"])
+    }
+
+    /// Wadoku ships 10,000 entries per bank, which is 50,000 bind parameters against SQLite's
+    /// 32,766 limit — the import failed outright until the inserts were chunked.
+    @Test func insertsABankLargerThanTheBindParameterLimit() throws {
+        guard let dictionary = makeDictionary("BigBank") else { Issue.record("no dictionary"); return }
+        defer { forget(dictionary) }
+
+        let rows = (0..<10_000).map { index in
+            TermMetaInsertion(term: "語\(index)", reading: "", mode: "freq",
+                              data: blob(#"{"value":1,"displayValue":"1"}"#),
+                              dictionaryId: dictionary.id)
+        }
+        #expect(SQLiteManager.shared.insertTermMeta(metaInsert: rows) != nil)
+
+        for index in [0, 5_000, 9_999] {
+            let found = SQLiteManager.shared.findTermMeta(texts: ["語\(index)"])
+                .filter { $0.dictionary.id == dictionary.id }
+            #expect(found.count == 1, "語\(index) missing after a large insert")
+        }
+    }
+
+    /// Deleting removes the dictionary at once and clears its entries afterwards, resuming from
+    /// whatever is still orphaned — so being interrupted strands nothing.
+    @Test func purgesDeletedEntriesAndResumesIfInterrupted() throws {
+        guard let dictionary = makeDictionary("PurgeMe") else { Issue.record("no dictionary"); return }
+        SQLiteManager.shared.purgeOrphanedEntries()
+
+        let rows = (0..<400).map { index in
+            TermMetaInsertion(term: "purge\(index)", reading: "", mode: "freq",
+                              data: blob(#"{"value":1,"displayValue":"1"}"#),
+                              dictionaryId: dictionary.id)
+        }
+        #expect(SQLiteManager.shared.insertTermMeta(metaInsert: rows) != nil)
+
+        try SQLiteManager.shared.deleteDictionary(dictionaryId: dictionary.id)
+        AppManager.shared.dictionaries.removeAll { $0.id == dictionary.id }
+
+        // Invisible immediately, even though the rows are still on disk.
+        #expect(SQLiteManager.shared.findTermMeta(texts: ["purge0"]).isEmpty)
+        #expect(remaining(dictionary) == 400)
+
+        var batchesAllowed = 2
+        SQLiteManager.shared.purgeOrphanedEntries(batchSize: 50) {
+            defer { batchesAllowed -= 1 }
+            return batchesAllowed > 0
+        }
+        let afterInterruption = remaining(dictionary)
+        #expect(afterInterruption < 400 && afterInterruption > 0)
+
+        SQLiteManager.shared.purgeOrphanedEntries(batchSize: 50)
+        #expect(remaining(dictionary) == 0)
+    }
+
+}

--- a/riidaaTests/TermMetaTests.swift
+++ b/riidaaTests/TermMetaTests.swift
@@ -1,0 +1,79 @@
+//
+//  TermMetaTests.swift
+//  riidaaTests
+//
+
+import Foundation
+import Testing
+@testable import riidaa
+
+struct TermMetaTests {
+
+    private func json(_ raw: String) -> Any {
+        try! JSONSerialization.jsonObject(with: raw.data(using: .utf8)!, options: [.fragmentsAllowed])
+    }
+
+    private func dictionary(_ title: String) -> DictionaryDB {
+        DictionaryDB(id: 1, revision: "", title: title, format: 3)
+    }
+
+    /// Both shapes JPDB ships: a bare rating for kana entries and a reading-scoped one for
+    /// words written in kanji. The spec also allows a plain number or string.
+    @Test func parsesTheFrequencyShapesRealDictionariesUse() throws {
+        let bare = try #require(TermMetaParser.parse(mode: "freq", data: json(#"{"value": 1, "displayValue": "1㋕"}"#)))
+        #expect(bare.reading == "")
+        guard case .frequency(let a) = bare.content else { Issue.record("not a frequency"); return }
+        #expect(a.value == 1 && a.display == "1㋕")
+
+        let scoped = try #require(TermMetaParser.parse(
+            mode: "freq", data: json(#"{"reading": "おもう", "frequency": {"value": 20, "displayValue": "20"}}"#)
+        ))
+        #expect(scoped.reading == "おもう")
+
+        let number = try #require(TermMetaParser.parse(mode: "freq", data: json("1234")))
+        guard case .frequency(let b) = number.content else { Issue.record("not a frequency"); return }
+        #expect(b.value == 1234)
+
+        #expect(TermMetaParser.parse(mode: "ipa", data: json(#"{"reading":"x"}"#)) == nil)
+        #expect(TermMetaParser.parse(mode: "freq", data: json(#"{"nonsense": true}"#)) == nil)
+    }
+
+    @Test func parsesPitchWithDevoicing() throws {
+        let parsed = try #require(TermMetaParser.parse(
+            mode: "pitch", data: json(#"{"reading": "しんぴ", "pitches": [{"position": 1, "devoice": [2]}]}"#)
+        ))
+        #expect(parsed.reading == "しんぴ")
+        guard case .pitch(let accents) = parsed.content else { Issue.record("not a pitch"); return }
+        #expect(accents == [PitchAccent(position: 1, devoice: [2])])
+    }
+
+    @Test func namesThePitchPatternFromTheMoraCount() {
+        #expect(PitchAccent(position: 0, devoice: []).category(moraCount: 4) == "heiban")
+        #expect(PitchAccent(position: 1, devoice: []).category(moraCount: 4) == "atamadaka")
+        #expect(PitchAccent(position: 2, devoice: []).category(moraCount: 4) == "nakadaka")
+        #expect(PitchAccent(position: 4, devoice: []).category(moraCount: 4) == "odaka")
+
+        #expect(PitchAccent.moraCount(of: "きょう") == 2)
+        #expect(PitchAccent.moraCount(of: "がっこう") == 4)
+    }
+
+    /// 夫妻 carries two ratings under one reading in JPDB, so neither may be collapsed — but a
+    /// rating filed under both the term and its reading comes back twice and must be.
+    @Test func summarisesWithoutLosingOrDuplicatingRatings() {
+        let meta = [
+            TermMetaDB(term: "夫妻", reading: "ふさい", dictionary: dictionary("JPDB"),
+                       content: .frequency(TermFrequency(value: 6923, display: "6923"))),
+            TermMetaDB(term: "夫妻", reading: "ふさい", dictionary: dictionary("JPDB"),
+                       content: .frequency(TermFrequency(value: 55898, display: "55898㋕"))),
+            TermMetaDB(term: "夫妻", reading: "ふさい", dictionary: dictionary("JPDB"),
+                       content: .frequency(TermFrequency(value: 6923, display: "6923"))),
+            TermMetaDB(term: "夫妻", reading: "ふうさい", dictionary: dictionary("JPDB"),
+                       content: .frequency(TermFrequency(value: 1, display: "1"))),
+        ]
+        let summary = TermMetaSummary(meta: meta, reading: "ふさい")
+        #expect(summary.frequencyLabels == ["JPDB: 6923", "JPDB: 55898㋕"])
+        #expect(summary.frequencySortValue == 6923)
+        #expect(TermMetaSummary(meta: [], reading: "ねこ").isEmpty)
+    }
+
+}


### PR DESCRIPTION
# Description

Pitch-accent and frequency dictionaries currently appear not to import. `DictionariesView` looks for `term_bank_*.json`, but those dictionaries contain only `term_meta_bank_*.json`, so the dictionary gets created, no term banks are found, and it ends up in the list with no entries.

This reads `term_meta_bank_*.json` into a new `term_meta` table and shows the results: pitch position and pattern, and frequency ratings.

**Changes made along the way**
- `insertMany` puts every row into one statement, which goes over SQLite's 32,766 bind-parameter limit on banks above ~3,600 rows. Inserts are now chunked, one transaction per bank.
- Extracted zips weren't being deleted - Jitendex unpacks to around 500 MB, and a copy was left after each import, update and delete.
- A failed import left the dictionary row in place, so it kept contributing partial results.
- Deleting scanned every row of both tables, as there was no index on `dictionaryId`. Deletion is now immediate with entries cleared in the background, and it resumes if interrupted.
- The `addColumn` migration throws once the column exists, which stopped anything sequenced after it from running.
- Import, update and delete were driven from view state, so leaving the screen looked like it cancelled them. They now run on `AppManager` with progress.
- Launch no longer waits on the database opening.
- Re-importing an installed dictionary is refused, matched on `indexUrl`.