### PR TITLE
Extend Anki export

### DIFF
--- a/riidaa/AppManager.swift
+++ b/riidaa/AppManager.swift
@@ -14,44 +14,112 @@ class AppManager : ObservableObject {
     
     @Published var isLoading = true
     @Published var dictionaries: [DictionaryDB] = []
+
+    @Published var deleting: Set<Int64> = []
+    @Published var purging: PurgeProgress? = nil
+
+    @Published var working: [Int64: DictionaryProgress] = [:]
+    @Published var preparing: DictionaryProgress? = nil
+    @Published var lastError: String? = nil
+    
+    func deleteDictionary(id: Int64) {
+        guard !deleting.contains(id) else { return }
+        deleting.insert(id)
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            try? SQLiteManager.shared.deleteDictionary(dictionaryId: id)
+            DispatchQueue.main.async {
+                self.dictionaries.removeAll { $0.id == id }
+                self.deleting.remove(id)
+            }
+            self.purgeOrphanedEntries()
+        }
+    }
+
+    func purgeOrphanedEntries() {
+        purgeQueue.async {
+            SQLiteManager.shared.purgeOrphanedEntries(progress: { cleared, total in
+                let update = PurgeProgress(cleared: cleared, total: total)
+                DispatchQueue.main.async {
+                    self.purging = update.isFinished ? nil : update
+                }
+            })
+            DispatchQueue.main.async { self.purging = nil }
+        }
+    }
+
+    private let purgeQueue = DispatchQueue(label: "dev.repierre.riidaa.purge", qos: .utility)
+
+    func setProgress(_ progress: DictionaryProgress?, for id: Int64?) {
+        DispatchQueue.main.async {
+            guard let id = id else {
+                self.preparing = progress
+                return
+            }
+            self.preparing = nil
+            if let progress = progress {
+                self.working[id] = progress
+            } else {
+                self.working.removeValue(forKey: id)
+            }
+        }
+    }
+
+    func report(error: String?) {
+        DispatchQueue.main.async {
+            self.lastError = error
+            self.preparing = nil
+        }
+    }
     
     private init() {
-        DispatchQueue.main.async {
-            self.loadDictionaries()
-        }
+        loadDictionaries()
+        discardExtractedDictionaries()
+        purgeOrphanedEntries()
     }
-    
-    func loadDictionaries() {
-        self.isLoading = true
-        
-        do {
-            for row in try SQLiteManager.shared.getDatabase()!.prepare(SQLiteManager.shared.dictionaries) {
-                dictionaries.append(DictionaryDB(
-                    id: row[SQLiteManager.shared.id],
-                    revision: row[SQLiteManager.shared.revision],
-                    title: row[SQLiteManager.shared.title],
-                    sequenced: row[SQLiteManager.shared.sequenced],
-                    format: row[SQLiteManager.shared.format],
-                    author: row[SQLiteManager.shared.author],
-                    isUpdatable: row[SQLiteManager.shared.isUpdatable],
-                    indexUrl: row[SQLiteManager.shared.indexUrl],
-                    downloadUrl: row[SQLiteManager.shared.downloadUrl],
-                    url: row[SQLiteManager.shared.url],
-                    description: row[SQLiteManager.shared.description],
-                    attribution: row[SQLiteManager.shared.attribution],
-                    sourceLanguage: row[SQLiteManager.shared.sourceLanguage],
-                    targetLanguage: row[SQLiteManager.shared.targetLanguage],
-                    frequencyMode: row[SQLiteManager.shared.frequencyMode]
-                ))
+
+    /// Removes leftover extractions
+    private func discardExtractedDictionaries() {
+        let fileManager = FileManager.default
+        guard let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            return
+        }
+        let root = documents.appendingPathComponent("dictionaries")
+
+        guard let leftovers = try? fileManager.contentsOfDirectory(at: root, includingPropertiesForKeys: nil),
+              !leftovers.isEmpty else {
+            return
+        }
+
+        DispatchQueue.global(qos: .utility).async {
+            for leftover in leftovers {
+                try? fileManager.removeItem(at: leftover)
             }
-//            for row in try SQLiteManager.shared.getDatabase()!.prepare(SQLiteManager.shared.terms) {
-//                readings.append(row[SQLiteManager.shared.reading])
-//            }
-        } catch {
-            
         }
-        
-        self.isLoading = false
+    }
+
+    func loadDictionaries() {
+        DispatchQueue.main.async { self.isLoading = true }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let loaded = SQLiteManager.shared.allDictionaries()
+            DispatchQueue.main.async {
+                self.dictionaries = loaded
+                self.isLoading = false
+            }
+        }
     }
     
+}
+
+struct PurgeProgress: Equatable {
+    let cleared: Int
+    let total: Int
+
+    var fraction: Double {
+        guard total > 0 else { return 0 }
+        return min(1, Double(cleared) / Double(total))
+    }
+
+    var isFinished: Bool { cleared >= total }
 }

--- a/riidaa/Models/AnkiExport.swift
+++ b/riidaa/Models/AnkiExport.swift
@@ -1,0 +1,235 @@
+//
+//  AnkiExport.swift
+//  riidaa
+//
+
+import Foundation
+
+/// One value a lookup can contribute to an Anki note. Raw values are persisted in
+/// `SettingsModel.ankiFields`, so renaming a case drops that mapping for existing users.
+enum AnkiFieldToken: String, CaseIterable, Identifiable {
+    case word
+    case reading
+    case furigana
+    case audio
+    case picture
+    case pitch
+    case pitchCategories
+    case frequency
+    case frequencySort
+    case meaning
+    case glossary
+    case sentence
+    case source
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .word: return "word"
+        case .reading: return "reading"
+        case .furigana: return "furigana"
+        case .audio: return "word audio"
+        case .picture: return "page image"
+        case .pitch: return "pitch accent"
+        case .pitchCategories: return "pitch pattern"
+        case .frequency: return "frequency"
+        case .frequencySort: return "frequency (sort value)"
+        case .meaning: return "meaning"
+        case .glossary: return "full glossary"
+        case .sentence: return "sentence"
+        case .source: return "source"
+        }
+    }
+}
+
+extension AnkiFieldToken {
+
+    /// Field names
+    var fieldNameAliases: [String] {
+        switch self {
+        case .word:
+            return ["word", "expression", "term", "vocab", "vocabulary", "kanji", "front"]
+        case .reading:
+            return ["reading", "wordreading", "expressionreading", "kana", "yomi"]
+        case .furigana:
+            return ["furigana", "wordfurigana", "expressionfurigana", "kanafurigana", "reading furigana"]
+        case .audio:
+            return ["wordaudio", "expressionaudio", "audio", "termaudio", "pronunciation"]
+        case .picture:
+            return ["picture", "image", "screenshot", "definitionpicture"]
+        case .pitch:
+            return ["pitch", "pitchaccent", "pitchposition", "accent"]
+        case .pitchCategories:
+            return ["pitchcategories", "pitchpattern", "pitchaccentcategories", "pitchaccentnotes"]
+        case .frequency:
+            return ["frequency", "freq", "frequencies"]
+        case .frequencySort:
+            return ["freqsort", "frequencysort", "sortfrequency"]
+        case .meaning:
+            return ["meaning", "maindefinition", "definition", "wordmeaning", "back"]
+        case .glossary:
+            return ["glossary", "glossaries", "definitions", "fullglossary"]
+        case .sentence:
+            return ["sentence", "examplesentence", "example", "context"]
+        case .source:
+            return ["source", "miscinfo", "notes", "book", "title"]
+        }
+    }
+
+    /// Exact matches only, so an unfamiliar note type maps nothing rather than misfiling.
+    static func suggestedMapping(for fields: [String]) -> [AnkiFieldToken: String] {
+        func normalized(_ name: String) -> String {
+            name.lowercased().filter { $0.isLetter || $0.isNumber }
+        }
+        let candidates = fields.map { (name: $0, key: normalized($0)) }
+
+        var mapping: [AnkiFieldToken: String] = [:]
+        var claimed = Set<String>()
+        for token in AnkiFieldToken.allCases {
+            for alias in token.fieldNameAliases.map(normalized) {
+                guard let match = candidates.first(where: { !claimed.contains($0.name) && $0.key == alias })
+                else {
+                    continue
+                }
+                mapping[token] = match.name
+                claimed.insert(match.name)
+                break
+            }
+        }
+        return mapping
+    }
+}
+
+struct MangaSource: Equatable {
+    let title: String
+    let volume: Int64
+    let page: Int64
+
+    var formatted: String {
+        "\(title) vol.\(volume) p.\(page)"
+    }
+}
+
+/// The word as it appears in the sentence
+struct SentenceMatch {
+    let surface: String
+    let offset: Int
+}
+
+/// The lookup being exported.
+struct AnkiNoteContext {
+    let term: TermDB
+    let sentence: String
+    let source: MangaSource?
+    var match: SentenceMatch? = nil
+    var meta: [TermMetaDB] = []
+    var audioURL: URL? = nil
+    var pictureURL: URL? = nil
+
+    private var summary: TermMetaSummary {
+        TermMetaSummary(meta: meta, reading: term.reading)
+    }
+
+    /// Falls back to the plain sentence if the match doesn't land where it claims, so a stale
+    /// offset can't corrupt the text.
+    private var emphasizedSentence: String {
+        guard let match = match, !match.surface.isEmpty else { return sentence }
+        let characters = Array(sentence)
+        let end = match.offset + match.surface.count
+        guard match.offset >= 0, end <= characters.count,
+              String(characters[match.offset..<end]) == match.surface else {
+            return sentence
+        }
+        return String(characters[0..<match.offset])
+            + "<b>" + match.surface + "</b>"
+            + String(characters[end...])
+    }
+
+    func value(for token: AnkiFieldToken) -> String? {
+        let value: String?
+        switch token {
+        case .word:
+            value = term.term
+        case .reading:
+            value = term.reading
+        case .furigana:
+            value = Furigana.annotate(term: term.term, reading: term.reading)
+        case .audio:
+            value = audioURL?.absoluteString
+        case .picture:
+            value = pictureURL?.absoluteString
+        case .pitch:
+            value = summary.pitchPositions.joined(separator: " ")
+        case .pitchCategories:
+            value = summary.pitchCategories.joined(separator: ",")
+        case .frequency:
+            value = summary.frequencyLabels.joined(separator: "<br>")
+        case .frequencySort:
+            value = summary.frequencySortValue.map(String.init)
+        case .meaning:
+            value = term.parseDefinition.first?.description
+        case .glossary:
+            // Deinflection entries are navigation hints, not meanings.
+            value = term.parseDefinition
+                .filter { definition in
+                    if case .deinflection = definition { return false }
+                    return true
+                }
+                .map(\.description)
+                .joined(separator: "<br>")
+        case .sentence:
+            value = emphasizedSentence
+        case .source:
+            value = source?.formatted
+        }
+        guard let value = value, !value.isEmpty else { return nil }
+        return value
+    }
+}
+
+/// Builds the `anki://x-callback-url/addnote` URL. Media can't be embedded: AnkiMobile
+/// downloads a field whose value is a URL to an image or audio file, so it travels by reference.
+struct AnkiExport {
+    let profile: String
+    let deck: String
+    let noteType: String
+    let fields: [AnkiFieldToken: String]
+
+    private static let queryValueAllowed = CharacterSet.urlQueryAllowed
+        .subtracting(CharacterSet(charactersIn: "&=+?#"))
+
+    /// Nil when the note would carry no fields.
+    func addNoteURL(context: AnkiNoteContext, callback: String) -> URL? {
+        guard
+            let profileEncoded = AnkiExport.encoded(profile),
+            let deckEncoded = AnkiExport.encoded(deck),
+            let noteTypeEncoded = AnkiExport.encoded(noteType),
+            let callbackEncoded = AnkiExport.encoded(callback)
+        else {
+            return nil
+        }
+
+        var query = ""
+        for token in AnkiFieldToken.allCases {
+            guard
+                let field = fields[token],
+                let fieldEncoded = AnkiExport.encoded(field),
+                let value = context.value(for: token),
+                let valueEncoded = AnkiExport.encoded(value)
+            else {
+                continue
+            }
+            query += "&fld\(fieldEncoded)=\(valueEncoded)"
+        }
+        if query.isEmpty {
+            return nil
+        }
+
+        return URL(string: "anki://x-callback-url/addnote?profile=\(profileEncoded)&deck=\(deckEncoded)&type=\(noteTypeEncoded)&x-success=\(callbackEncoded)\(query)")
+    }
+
+    private static func encoded(_ value: String) -> String? {
+        value.addingPercentEncoding(withAllowedCharacters: queryValueAllowed)
+    }
+}

--- a/riidaa/Models/AnkiExport.swift
+++ b/riidaa/Models/AnkiExport.swift
@@ -20,6 +20,7 @@ enum AnkiFieldToken: String, CaseIterable, Identifiable {
     case meaning
     case glossary
     case sentence
+    case sentenceFurigana
     case source
 
     var id: String { rawValue }
@@ -38,6 +39,7 @@ enum AnkiFieldToken: String, CaseIterable, Identifiable {
         case .meaning: return "meaning"
         case .glossary: return "full glossary"
         case .sentence: return "sentence"
+        case .sentenceFurigana: return "sentence (furigana field)"
         case .source: return "source"
         }
     }
@@ -72,6 +74,8 @@ extension AnkiFieldToken {
             return ["glossary", "glossaries", "definitions", "fullglossary"]
         case .sentence:
             return ["sentence", "examplesentence", "example", "context"]
+        case .sentenceFurigana:
+            return ["sentencefurigana", "examplesentencefurigana"]
         case .source:
             return ["source", "miscinfo", "notes", "book", "title"]
         }
@@ -146,6 +150,45 @@ struct AnkiNoteContext {
             + String(characters[end...])
     }
 
+    /// Like `description`, but without the part-of-speech tags.
+    static func glossary(_ definition: ContentDefinition) -> String {
+        if case .detailed(let content) = definition {
+            return glossary(content)
+        }
+        return definition.description
+    }
+
+    private static func glossary(_ content: StructuredContent) -> String {
+        switch content {
+        case .array(let rows):
+            return rows
+                .filter { row in
+                    row.contains { element in
+                        if case .inlineContainer = element { return false }
+                        return true
+                    }
+                }
+                .map { row in row.map(glossary).filter { !$0.isEmpty }.joined(separator: ", ") }
+                .filter { !$0.isEmpty }
+                .joined(separator: "<br>")
+        case .container(let container), .inlineContainer(let container):
+            return glossary(container.data)
+        case .table(let table):
+            return glossary(table.data)
+        case .link(let link):
+            return glossary(link.data)
+        case .numberedList(let list), .list(let list):
+            return list.content
+                .map { row in row.map(glossary).joined(separator: " ") }
+                .filter { !$0.isEmpty }
+                .joined(separator: ", ")
+        case .text(let string):
+            return string.content
+        case .newline:
+            return "<br>"
+        }
+    }
+
     func value(for token: AnkiFieldToken) -> String? {
         let value: String?
         switch token {
@@ -168,7 +211,7 @@ struct AnkiNoteContext {
         case .frequencySort:
             value = summary.frequencySortValue.map(String.init)
         case .meaning:
-            value = term.parseDefinition.first?.description
+            value = term.parseDefinition.first.map(AnkiNoteContext.glossary)
         case .glossary:
             // Deinflection entries are navigation hints, not meanings.
             value = term.parseDefinition
@@ -176,9 +219,9 @@ struct AnkiNoteContext {
                     if case .deinflection = definition { return false }
                     return true
                 }
-                .map(\.description)
+                .map(AnkiNoteContext.glossary)
                 .joined(separator: "<br>")
-        case .sentence:
+        case .sentence, .sentenceFurigana:
             value = emphasizedSentence
         case .source:
             value = source?.formatted

--- a/riidaa/Models/AnkiExport.swift
+++ b/riidaa/Models/AnkiExport.swift
@@ -14,6 +14,7 @@ enum AnkiFieldToken: String, CaseIterable, Identifiable {
     case audio
     case picture
     case pitch
+    case pitchGraph
     case pitchCategories
     case frequency
     case frequencySort
@@ -32,7 +33,8 @@ enum AnkiFieldToken: String, CaseIterable, Identifiable {
         case .furigana: return "furigana"
         case .audio: return "word audio"
         case .picture: return "page image"
-        case .pitch: return "pitch accent"
+        case .pitch: return "pitch accent (position)"
+        case .pitchGraph: return "pitch accent (diagram)"
         case .pitchCategories: return "pitch pattern"
         case .frequency: return "frequency"
         case .frequencySort: return "frequency (sort value)"
@@ -61,7 +63,9 @@ extension AnkiFieldToken {
         case .picture:
             return ["picture", "image", "screenshot", "definitionpicture"]
         case .pitch:
-            return ["pitch", "pitchaccent", "pitchposition", "accent"]
+            return ["pitchposition", "pitch", "accent"]
+        case .pitchGraph:
+            return ["pitchaccent", "pitchgraph", "pitchdiagram"]
         case .pitchCategories:
             return ["pitchcategories", "pitchpattern", "pitchaccentcategories", "pitchaccentnotes"]
         case .frequency:
@@ -204,6 +208,8 @@ struct AnkiNoteContext {
             value = pictureURL?.absoluteString
         case .pitch:
             value = summary.pitchPositions.joined(separator: " ")
+        case .pitchGraph:
+            value = summary.pitchGraphs.joined(separator: " ")
         case .pitchCategories:
             value = summary.pitchCategories.joined(separator: ",")
         case .frequency:

--- a/riidaa/Models/Dictionary/TermMeta.swift
+++ b/riidaa/Models/Dictionary/TermMeta.swift
@@ -18,11 +18,69 @@ public struct PitchAccent: Hashable {
 
     /// Small kana combine with the preceding mora
     public static func moraCount(of reading: String) -> Int {
+        morae(of: reading).count
+    }
+
+    /// Katakana, as pitch is conventionally written; small kana join the preceding mora.
+    static func morae(of reading: String) -> [String] {
         let combining: Set<Character> = [
-            "ゃ", "ゅ", "ょ", "ぁ", "ぃ", "ぅ", "ぇ", "ぉ", "ゎ",
             "ャ", "ュ", "ョ", "ァ", "ィ", "ゥ", "ェ", "ォ", "ヮ",
         ]
-        return reading.filter { !combining.contains($0) }.count
+        var morae: [String] = []
+        for character in reading {
+            var kana = character
+            if let scalar = character.unicodeScalars.first,
+               character.unicodeScalars.count == 1,
+               (0x3041...0x3096).contains(scalar.value),
+               let shifted = UnicodeScalar(scalar.value + 0x60) {
+                kana = Character(shifted)
+            }
+            if combining.contains(kana), !morae.isEmpty {
+                morae[morae.count - 1].append(kana)
+            } else {
+                morae.append(String(kana))
+            }
+        }
+        return morae
+    }
+
+    /// The pattern drawn as Yomitan and the Kaishi deck draw it
+    public func graph(reading: String) -> String {
+        let overline = "border-color:currentColor;display:block;user-select:none;"
+            + "pointer-events:none;position:absolute;top:0.1em;left:0;right:0;height:0;"
+            + "border-top-width:0.1em;border-top-style:solid;"
+        let drop = "right:-0.1em;height:0.4em;border-right-width:0.1em;border-right-style:solid;"
+
+        let morae = PitchAccent.morae(of: reading)
+        guard !morae.isEmpty else { return "" }
+
+        func isHigh(_ mora: Int) -> Bool {
+            if position == 0 { return mora > 1 }
+            if position == 1 { return mora == 1 }
+            return mora >= 2 && mora <= position
+        }
+
+        var html = ""
+        var index = 0
+        while index < morae.count {
+            let high = isHigh(index + 1)
+            var end = index
+            while end < morae.count, isHigh(end + 1) == high { end += 1 }
+            let text = morae[index..<end].joined()
+
+            if high {
+                let dropsHere = position > 0 && end == position
+                let outer = dropsHere
+                    ? "display:inline-block;position:relative;padding-right:0.1em;margin-right:0.1em;"
+                    : "display:inline-block;position:relative;"
+                html += "<span style=\"\(outer)\"><span style=\"display:inline;\">\(text)</span>"
+                    + "<span style=\"\(overline)\(dropsHere ? drop : "")\"></span></span>"
+            } else {
+                html += text
+            }
+            index = end
+        }
+        return html
     }
 }
 
@@ -135,6 +193,10 @@ public struct TermMetaSummary {
 
     public var pitchPositions: [String] {
         deduplicated(pitches.map { "[\($0.position)]" })
+    }
+
+    public var pitchGraphs: [String] {
+        deduplicated(pitches.map { $0.graph(reading: reading) })
     }
 
     public var pitchCategories: [String] {

--- a/riidaa/Models/Dictionary/TermMeta.swift
+++ b/riidaa/Models/Dictionary/TermMeta.swift
@@ -1,0 +1,160 @@
+//
+//  TermMeta.swift
+//  riidaa
+//
+
+import Foundation
+
+public struct PitchAccent: Hashable {
+    public let position: Int
+    public let devoice: [Int]
+
+    public func category(moraCount: Int) -> String {
+        if position == 0 { return "heiban" }
+        if position == 1 { return "atamadaka" }
+        if position >= moraCount { return "odaka" }
+        return "nakadaka"
+    }
+
+    /// Small kana combine with the preceding mora
+    public static func moraCount(of reading: String) -> Int {
+        let combining: Set<Character> = [
+            "ゃ", "ゅ", "ょ", "ぁ", "ぃ", "ぅ", "ぇ", "ぉ", "ゎ",
+            "ャ", "ュ", "ョ", "ァ", "ィ", "ゥ", "ェ", "ォ", "ヮ",
+        ]
+        return reading.filter { !combining.contains($0) }.count
+    }
+}
+
+public struct TermFrequency: Hashable {
+    public let value: Int64?
+    public let display: String
+}
+
+public struct TermMetaDB: Hashable {
+    public enum Content: Hashable {
+        case frequency(TermFrequency)
+        case pitch([PitchAccent])
+    }
+
+    public let term: String
+    public let reading: String
+    let dictionary: DictionaryDB
+    public let content: Content
+
+    public func applies(toReading termReading: String) -> Bool {
+        reading.isEmpty || reading == termReading
+    }
+}
+
+public struct TermMetaParser {
+
+    /// Decodes the `data` element of a `[term, mode, data]` triple, or nil
+    /// doesn't handle and data that doesn't match the spec.
+    public static func parse(mode: String, data: Any) -> (reading: String, content: TermMetaDB.Content)? {
+        switch mode {
+        case "freq":
+            return parseFrequency(data)
+        case "pitch":
+            return parsePitch(data)
+        default:
+            return nil
+        }
+    }
+
+    private static func parseFrequency(_ data: Any) -> (reading: String, content: TermMetaDB.Content)? {
+        if let map = data as? [String: Any], let reading = map["reading"] as? String {
+            guard let inner = map["frequency"], let frequency = frequencyValue(inner) else { return nil }
+            return (reading, .frequency(frequency))
+        }
+        guard let frequency = frequencyValue(data) else { return nil }
+        return ("", .frequency(frequency))
+    }
+
+    private static func frequencyValue(_ data: Any) -> TermFrequency? {
+        if let number = data as? Int64 {
+            return TermFrequency(value: number, display: String(number))
+        }
+        if let number = data as? Int {
+            return TermFrequency(value: Int64(number), display: String(number))
+        }
+        if let number = data as? Double {
+            return TermFrequency(value: Int64(number), display: String(Int64(number)))
+        }
+        if let text = data as? String {
+            return TermFrequency(value: Int64(text), display: text)
+        }
+        if let map = data as? [String: Any] {
+            let value = (map["value"] as? Int).map(Int64.init) ?? (map["value"] as? Int64)
+            let display = map["displayValue"] as? String ?? value.map(String.init)
+            guard let display = display else { return nil }
+            return TermFrequency(value: value, display: display)
+        }
+        return nil
+    }
+
+    private static func parsePitch(_ data: Any) -> (reading: String, content: TermMetaDB.Content)? {
+        guard let map = data as? [String: Any],
+              let reading = map["reading"] as? String,
+              let pitches = map["pitches"] as? [[String: Any]] else {
+            return nil
+        }
+        let accents: [PitchAccent] = pitches.compactMap { pitch in
+            guard let position = pitch["position"] as? Int else { return nil }
+            return PitchAccent(position: position, devoice: pitch["devoice"] as? [Int] ?? [])
+        }
+        guard !accents.isEmpty else { return nil }
+        return (reading, .pitch(accents))
+    }
+
+}
+
+/// Collapses the metadata applying to one term into the strings the lookup panel and the Anki
+/// export both read, so the two can't drift apart.
+public struct TermMetaSummary {
+    let pitches: [PitchAccent]
+    let frequencies: [(dictionary: String, frequency: TermFrequency)]
+    let reading: String
+
+    init(meta: [TermMetaDB], reading: String) {
+        self.reading = reading
+        let applicable = meta.filter { $0.applies(toReading: reading) }
+        self.pitches = applicable.flatMap { entry -> [PitchAccent] in
+            if case .pitch(let accents) = entry.content { return accents }
+            return []
+        }
+        self.frequencies = applicable.compactMap { entry in
+            if case .frequency(let frequency) = entry.content {
+                return (entry.dictionary.title, frequency)
+            }
+            return nil
+        }
+    }
+
+    public var isEmpty: Bool { pitches.isEmpty && frequencies.isEmpty }
+
+    public var pitchPositions: [String] {
+        deduplicated(pitches.map { "[\($0.position)]" })
+    }
+
+    public var pitchCategories: [String] {
+        let mora = PitchAccent.moraCount(of: reading)
+        return deduplicated(pitches.map { $0.category(moraCount: mora) })
+    }
+
+    /// Deduplicated: metadata is looked up under both the term and its reading, and a rating
+    /// filed under both comes back twice.
+    public var frequencyLabels: [String] {
+        deduplicated(frequencies.map { "\($0.dictionary): \($0.frequency.display)" })
+    }
+
+    /// Lower means more common.
+    public var frequencySortValue: Int64? {
+        frequencies.compactMap { $0.frequency.value }.min()
+    }
+
+    private func deduplicated(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        return values.filter { seen.insert($0).inserted }
+    }
+}

--- a/riidaa/Models/SettingsModel.swift
+++ b/riidaa/Models/SettingsModel.swift
@@ -25,6 +25,9 @@ class SettingsModel: ObservableObject {
     
     @AppStorage("padding") var padding = 0.0
     @AppStorage("isLTR") var isLTR = false
+
+    /// Word audio comes from a third-party service (see `WordAudio`), so it can be turned off.
+    @AppStorage("wordAudioEnabled") var wordAudioEnabled = true
     
     @Published var ankiInfo: AnkiInfo? {
         didSet { save(ankiInfo, forKey: "ankiInfo") }
@@ -36,21 +39,15 @@ class SettingsModel: ObservableObject {
         didSet { save(ankiDeck, forKey: "ankiDeck") }
     }
     @Published var ankiNoteType: AnkiInfo.NoteType? {
-        didSet { save(ankiNoteType, forKey: "ankiNoteType") }
+        didSet {
+            save(ankiNoteType, forKey: "ankiNoteType")
+            discardMappingsMissingFromNoteType()
+        }
     }
-    @Published var ankiFieldWord: String? {
-        didSet { save(ankiFieldWord, forKey: "ankiFieldWord") }
+    @Published var ankiFields: [String: String] = [:] {
+        didSet { save(ankiFields, forKey: "ankiFields") }
     }
-    @Published var ankiFieldMeaning: String? {
-        didSet { save(ankiFieldMeaning, forKey: "ankiFieldMeaning") }
-    }
-    @Published var ankiFieldReading: String? {
-        didSet { save(ankiFieldReading, forKey: "ankiFieldReading") }
-    }
-    @Published var ankiFieldExample: String? {
-        didSet { save(ankiFieldExample, forKey: "ankiFieldExample") }
-    }
-    
+
 #if APPSTORE
     var adult = false
 #else
@@ -96,12 +93,75 @@ class SettingsModel: ObservableObject {
         self.ankiProfile = load(forKey: "ankiProfile")
         self.ankiDeck = load(forKey: "ankiDeck")
         self.ankiNoteType = load(forKey: "ankiNoteType")
-        self.ankiFieldWord = load(forKey: "ankiFieldWord")
-        self.ankiFieldReading = load(forKey: "ankiFieldReading")
-        self.ankiFieldMeaning = load(forKey: "ankiFieldMeaning")
-        self.ankiFieldExample = load(forKey: "ankiFieldExample")
+        self.ankiFields = load(forKey: "ankiFields") ?? SettingsModel.migratedAnkiFields()
     }
-    
+
+    private static func migratedAnkiFields() -> [String: String] {
+        let legacyKeys: [(AnkiFieldToken, String)] = [
+            (.word, "ankiFieldWord"),
+            (.reading, "ankiFieldReading"),
+            (.meaning, "ankiFieldMeaning"),
+            (.sentence, "ankiFieldExample"),
+        ]
+        var fields: [String: String] = [:]
+        for (token, key) in legacyKeys {
+            guard let data = UserDefaults.standard.data(forKey: key),
+                  let field = try? JSONDecoder().decode(String.self, from: data) else {
+                continue
+            }
+            fields[token.rawValue] = field
+        }
+        return fields
+    }
+
+    private func discardMappingsMissingFromNoteType() {
+        guard let noteType = ankiNoteType else { return }
+        let available = Set(noteType.fields.map { $0.name })
+        let pruned = ankiFields.filter { available.contains($0.value) }
+        if pruned.count != ankiFields.count {
+            ankiFields = pruned
+        }
+    }
+
+    /// Fills unset tokens only, so a deliberate choice is never overwritten.
+    func autoMapAnkiFields(for noteType: AnkiInfo.NoteType) {
+        let suggestions = AnkiFieldToken.suggestedMapping(for: noteType.fields.map { $0.name })
+        var updated = ankiFields
+        let taken = Set(updated.values)
+        for (token, field) in suggestions where updated[token.rawValue] == nil && !taken.contains(field) {
+            updated[token.rawValue] = field
+        }
+        ankiFields = updated
+    }
+
+    func ankiFieldBinding(for token: AnkiFieldToken) -> Binding<String?> {
+        Binding(
+            get: { self.ankiFields[token.rawValue] },
+            set: { newValue in
+                if let newValue = newValue {
+                    self.ankiFields[token.rawValue] = newValue
+                } else {
+                    self.ankiFields.removeValue(forKey: token.rawValue)
+                }
+            }
+        )
+    }
+
+    var ankiExport: AnkiExport? {
+        guard let profile = ankiProfile, let deck = ankiDeck, let noteType = ankiNoteType else {
+            return nil
+        }
+        // Never send a field the note type doesn't have, whatever is stored.
+        let available = Set(noteType.fields.map { $0.name })
+        var fields: [AnkiFieldToken: String] = [:]
+        for token in AnkiFieldToken.allCases {
+            if let field = ankiFields[token.rawValue], available.contains(field) {
+                fields[token] = field
+            }
+        }
+        return AnkiExport(profile: profile.name, deck: deck.name, noteType: noteType.name, fields: fields)
+    }
+
     private func load<T: Codable>(forKey key: String) -> T? {
         guard let data = UserDefaults.standard.data(forKey: key) else { return nil }
         return try? JSONDecoder().decode(T.self, from: data)

--- a/riidaa/SQLiteManager.swift
+++ b/riidaa/SQLiteManager.swift
@@ -16,6 +16,7 @@ class SQLiteManager {
     // Table Definitions
     let dictionaries = Table("dictionaries")
     let terms = Table("terms")
+    let termMeta = Table("term_meta")
 
     // Dictionary
     let id = Expression<Int64>("id")
@@ -45,6 +46,18 @@ class SQLiteManager {
     let termTags = SQLite.Expression<String>("termTags")
     let dictionaryId = SQLite.Expression<Int64>("dictionaryId")
     let exportedToAnki = SQLite.Expression<Bool>("exportedToAnki")
+
+    // Term metadata
+    let metaMode = SQLite.Expression<String>("mode")
+    let metaReading = SQLite.Expression<String>("metaReading")
+    let metaData = SQLite.Expression<Data>("data")
+
+    /// Every statement runs here
+    private let access = DispatchQueue(label: "dev.repierre.riidaa.sqlite")
+
+    private func perform<T>(_ work: () throws -> T) rethrows -> T {
+        try access.sync(execute: work)
+    }
 
     private init() {
         do {
@@ -85,24 +98,135 @@ class SQLiteManager {
             })
             try db?.run(terms.createIndex(term, ifNotExists: true))
             try db?.run(terms.createIndex(reading, ifNotExists: true))
-            try db?.run(terms.addColumn(exportedToAnki, defaultValue: false))
+            try db?.run(terms.createIndex(dictionaryId, ifNotExists: true))
+
+            try db?.run(termMeta.create(ifNotExists: true) { t in
+                t.column(term)
+                t.column(metaReading)
+                t.column(metaMode)
+                t.column(metaData)
+                t.column(dictionaryId)
+                t.foreignKey(dictionaryId, references: dictionaries, id, delete: .cascade)
+            })
+            try db?.run(termMeta.createIndex(term, ifNotExists: true))
+            try db?.run(termMeta.createIndex(dictionaryId, ifNotExists: true))
         } catch {
             print("Database setup failed: \(error)")
+        }
+
+        do {
+            try db?.run(terms.addColumn(exportedToAnki, defaultValue: false))
+        } catch {
+            // Column already present.
+        }
+
+        do {
+            try db?.run("PRAGMA wal_checkpoint(TRUNCATE)")
+        } catch {
+            print("checkpoint failed: \(error)")
         }
     }
 
     func getDatabase() -> Connection? {
         return db
     }
+
+    func allDictionaries() -> [DictionaryDB] {
+        perform {
+            guard let db = db else { return [] }
+            var loaded: [DictionaryDB] = []
+            do {
+                for row in try db.prepare(dictionaries) {
+                    loaded.append(DictionaryDB(
+                        id: row[id],
+                        revision: row[revision],
+                        title: row[title],
+                        sequenced: row[sequenced],
+                        format: row[format],
+                        author: row[author],
+                        isUpdatable: row[isUpdatable],
+                        indexUrl: row[indexUrl],
+                        downloadUrl: row[downloadUrl],
+                        url: row[url],
+                        description: row[description],
+                        attribution: row[attribution],
+                        sourceLanguage: row[sourceLanguage],
+                        targetLanguage: row[targetLanguage],
+                        frequencyMode: row[frequencyMode]
+                    ))
+                }
+            } catch {
+                print("Failed to load dictionaries: \(error)")
+            }
+            return loaded
+        }
+    }
     
+    /// Removes the dictionary itself and nothing else.
     func deleteDictionary(dictionaryId: Int64) throws {
-        let terms = terms.filter(self.dictionaryId == dictionaryId)
-        try db!.run(terms.delete())
-        let dics = dictionaries.filter(id == dictionaryId)
-        try db!.run(dics.delete())
+        try perform {
+            guard let db = db else { return }
+            try db.run(dictionaries.filter(id == dictionaryId).delete())
+        }
+    }
+
+    /// Clears rows belonging to dictionaries that no longer exist, a batch at a time.
+    func purgeOrphanedEntries(
+        batchSize: Int = 750,
+        shouldContinue: () -> Bool = { true },
+        progress: ((_ cleared: Int, _ total: Int) -> Void)? = nil
+    ) {
+        let orphanCondition = "dictionaryId NOT IN (SELECT id FROM dictionaries)"
+        let tables = ["terms", "term_meta"]
+
+        let total: Int = perform {
+            guard let db = db else { return 0 }
+            return tables.reduce(0) { running, table in
+                let raw = try? db.scalar("SELECT count(*) FROM \(table) WHERE \(orphanCondition)")
+                guard let value = raw as? Int64 else { return running }
+                return running + Int(value)
+            }
+        }
+        guard total > 0 else { return }
+
+        var cleared = 0
+        var finished = false
+        progress?(cleared, total)
+
+        for table in tables {
+            let statement = "DELETE FROM \(table) WHERE rowid IN (SELECT rowid FROM \(table) WHERE \(orphanCondition) LIMIT ?)"
+            while shouldContinue() {
+                let removed: Int = perform {
+                    guard let db = db else { return 0 }
+                    do {
+                        try db.run(statement, batchSize)
+                        return db.changes
+                    } catch {
+                        print("purge failed: \(error)")
+                        return 0
+                    }
+                }
+                if removed == 0 { break }
+                cleared += removed
+                progress?(cleared, total)
+                finished = cleared >= total
+                // Let anything waiting on the database in ahead of the next batch.
+                Thread.sleep(forTimeInterval: 0.02)
+            }
+        }
+
+        if finished {
+            progress?(total, total)
+        }
     }
     
     func insertDictionary(revision: String, title: String, sequenced: Bool, format: Int, author: String?, isUpdatable: Bool, indexUrl: String?, downloadUrl: String?, url: String?, description: String?, attribution: String?, sourceLanguage: String?, targetLanguage: String?, frequencyMode: String?) -> DictionaryDB? {
+        perform {
+            insertDictionaryLocked(revision: revision, title: title, sequenced: sequenced, format: format, author: author, isUpdatable: isUpdatable, indexUrl: indexUrl, downloadUrl: downloadUrl, url: url, description: description, attribution: attribution, sourceLanguage: sourceLanguage, targetLanguage: targetLanguage, frequencyMode: frequencyMode)
+        }
+    }
+
+    private func insertDictionaryLocked(revision: String, title: String, sequenced: Bool, format: Int, author: String?, isUpdatable: Bool, indexUrl: String?, downloadUrl: String?, url: String?, description: String?, attribution: String?, sourceLanguage: String?, targetLanguage: String?, frequencyMode: String?) -> DictionaryDB? {
         let insertQuery = dictionaries.insert(
             self.title <- title,
             self.revision <- revision,
@@ -131,6 +255,33 @@ class SQLiteManager {
         return nil
     }
     
+    /// SQLite rejects a statement carrying more than SQLITE_MAX_VARIABLE_NUMBER bind
+    /// parameters — 32766 since 3.32. `insertMany` puts every row into a single statement, so a
+    /// large bank has to be split
+    private static let maxBindVariables = 32766
+
+    private func insert(into table: Table, setters: [[Setter]], columnsPerRow: Int) -> Int64? {
+        guard !setters.isEmpty else { return 0 }
+
+        let chunkSize = max(1, SQLiteManager.maxBindVariables / max(1, columnsPerRow))
+        return perform {
+            guard let db = db else { return nil }
+            var inserted: Int64 = 0
+            do {
+                try db.transaction {
+                    for start in stride(from: 0, to: setters.count, by: chunkSize) {
+                        let chunk = Array(setters[start..<min(start + chunkSize, setters.count)])
+                        inserted = try db.run(table.insertMany(or: .ignore, chunk))
+                    }
+                }
+                return inserted
+            } catch {
+                print("error: \(error)")
+                return nil
+            }
+        }
+    }
+
     func insertTerms(termsInsert: [TermInsertion]) -> Int64? {
         var setters: [[Setter]] = []
         for term in termsInsert {
@@ -146,16 +297,63 @@ class SQLiteManager {
                 self.dictionaryId <- term.dictionaryId
             ])
         }
-        let insertQuery = terms.insertMany(or: .ignore, setters)
+        return insert(into: terms, setters: setters, columnsPerRow: 9)
+    }
+    
+    func insertTermMeta(metaInsert: [TermMetaInsertion]) -> Int64? {
+        var setters: [[Setter]] = []
+        for meta in metaInsert {
+            setters.append([
+                self.term <- meta.term,
+                self.metaReading <- meta.reading,
+                self.metaMode <- meta.mode,
+                self.metaData <- meta.data,
+                self.dictionaryId <- meta.dictionaryId
+            ])
+        }
+        return insert(into: termMeta, setters: setters, columnsPerRow: 5)
+    }
+
+    func findTermMeta(texts: [String]) -> [TermMetaDB] {
+        perform { findTermMetaLocked(texts: texts) }
+    }
+
+    private func findTermMetaLocked(texts: [String]) -> [TermMetaDB] {
+        var result: [TermMetaDB] = []
+        guard let db = db else { return result }
+
+        let query = termMeta.filter(texts.contains(self.term))
         do {
-            return try db?.run(insertQuery)
+            for row in try db.prepare(query) {
+                guard let dictionary = AppManager.shared.dictionaries.first(where: {
+                    $0.id == row[self.dictionaryId]
+                }) else {
+                    continue
+                }
+                guard let raw = try? JSONSerialization.jsonObject(with: row[metaData]),
+                      let parsed = TermMetaParser.parse(mode: row[metaMode], data: raw) else {
+                    continue
+                }
+                result.append(
+                    TermMetaDB(
+                        term: row[self.term],
+                        reading: parsed.reading,
+                        dictionary: dictionary,
+                        content: parsed.content
+                    )
+                )
+            }
         } catch {
             print("error: \(error)")
         }
-        return nil
+        return result
     }
-    
+
     func findTerms(texts: [String]) -> [TermDB] {
+        perform { findTermsLocked(texts: texts) }
+    }
+
+    private func findTermsLocked(texts: [String]) -> [TermDB] {
         var result: [TermDB] = []
         
         guard let db = db else { return result }
@@ -199,6 +397,14 @@ class SQLiteManager {
         
         return result
     }
+}
+
+public struct TermMetaInsertion {
+    let term: String
+    let reading: String
+    let mode: String
+    let data: Data
+    let dictionaryId: Int64
 }
 
 public struct TermInsertion {

--- a/riidaa/Utils/Japanese/Furigana.swift
+++ b/riidaa/Utils/Japanese/Furigana.swift
@@ -1,0 +1,124 @@
+//
+//  Furigana.swift
+//  riidaa
+//
+
+import Foundation
+
+/// Builds Anki's furigana notation from a term and its reading.
+public struct Furigana {
+
+    public static func annotate(term: String, reading: String) -> String? {
+        guard !term.isEmpty else { return nil }
+        guard !reading.isEmpty, reading != term else { return term }
+
+        let termChars = Array(term)
+        let readingChars = Array(reading)
+        guard termChars.contains(where: { !isKana($0) }) else {
+            return "\(term)[\(reading)]"
+        }
+        return distributed(term: termChars, reading: readingChars)
+            ?? trimmed(term: termChars, reading: readingChars)
+    }
+
+    /// Gives each kanji run the slice of the reading ending where the next kana run starts
+    private static func distributed(term: [Character], reading: [Character]) -> String? {
+        let runs = runs(of: term)
+        var result = ""
+        var position = 0
+
+        for (index, run) in runs.enumerated() {
+            if run.isKana {
+                let end = position + run.characters.count
+                guard end <= reading.count, Array(reading[position..<end]) == run.characters else {
+                    return nil
+                }
+                result += String(run.characters)
+                position = end
+                continue
+            }
+
+            let end: Int
+            if index + 1 < runs.count {
+                guard let anchor = firstIndex(
+                    of: runs[index + 1].characters,
+                    in: reading,
+                    from: position + run.characters.count
+                ) else {
+                    return nil
+                }
+                end = anchor
+            } else {
+                end = reading.count
+            }
+            guard end > position else { return nil }
+
+            if !result.isEmpty {
+                result += " "
+            }
+            result += "\(String(run.characters))[\(String(reading[position..<end]))]"
+            position = end
+        }
+
+        guard position == reading.count else { return nil }
+        return result
+    }
+
+    /// Brackets everything between the kana the term and reading already share.
+    private static func trimmed(term: [Character], reading: [Character]) -> String {
+        var prefix = 0
+        while prefix < term.count, prefix < reading.count, term[prefix] == reading[prefix] {
+            prefix += 1
+        }
+
+        var suffix = 0
+        while suffix < term.count - prefix, suffix < reading.count - prefix,
+              term[term.count - 1 - suffix] == reading[reading.count - 1 - suffix] {
+            suffix += 1
+        }
+
+        let base = String(term[prefix..<(term.count - suffix)])
+        let baseReading = String(reading[prefix..<(reading.count - suffix)])
+        guard !base.isEmpty, !baseReading.isEmpty else { return String(term) }
+
+        let head = String(term[0..<prefix])
+        let tail = String(term[(term.count - suffix)...])
+        return "\(head)\(head.isEmpty ? "" : " ")\(base)[\(baseReading)]\(tail)"
+    }
+
+    private struct Run {
+        let characters: [Character]
+        let isKana: Bool
+    }
+
+    private static func runs(of term: [Character]) -> [Run] {
+        var runs: [Run] = []
+        for character in term {
+            let kana = isKana(character)
+            if let last = runs.last, last.isKana == kana {
+                runs[runs.count - 1] = Run(characters: last.characters + [character], isKana: kana)
+            } else {
+                runs.append(Run(characters: [character], isKana: kana))
+            }
+        }
+        return runs
+    }
+
+    private static func isKana(_ character: Character) -> Bool {
+        guard let scalar = character.unicodeScalars.first else { return false }
+        return (0x3041...0x309F).contains(scalar.value) || (0x30A1...0x30FF).contains(scalar.value)
+    }
+
+    private static func firstIndex(of needle: [Character], in haystack: [Character], from: Int) -> Int? {
+        guard !needle.isEmpty, from >= 0 else { return nil }
+        var start = from
+        while start + needle.count <= haystack.count {
+            if Array(haystack[start..<(start + needle.count)]) == needle {
+                return start
+            }
+            start += 1
+        }
+        return nil
+    }
+
+}

--- a/riidaa/Utils/Japanese/WordAudio.swift
+++ b/riidaa/Utils/Japanese/WordAudio.swift
@@ -1,0 +1,53 @@
+//
+//  WordAudio.swift
+//  riidaa
+//
+
+import Foundation
+
+/// Pronunciation audio from JapanesePod101's dictionary endpoint
+public struct WordAudio {
+
+    private static let endpoint = "https://assets.languagepod101.com/dictionary/japanese/audiomp3.php"
+
+    private static let cacheQueue = DispatchQueue(label: "dev.repierre.riidaa.wordaudio")
+    private static var availabilityCache: [URL: Bool] = [:]
+
+    public static func url(term: String, reading: String) -> URL? {
+        let kanji = term.trimmingCharacters(in: .whitespacesAndNewlines)
+        let kana = reading.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !kanji.isEmpty || !kana.isEmpty else { return nil }
+
+        var components = URLComponents(string: endpoint)
+        components?.queryItems = [
+            URLQueryItem(name: "kanji", value: kanji.isEmpty ? kana : kanji),
+            URLQueryItem(name: "kana", value: kana.isEmpty ? kanji : kana),
+            URLQueryItem(name: "fakePath", value: "audio.mp3"),
+        ]
+        return components?.url
+    }
+
+    /// The endpoint never 404s: a word it knows redirects to a CDN copy, one it doesn't serves a
+    /// fixed "not found" clip from the requested URL
+    static func isRecording(requested: URL, resolved: URL?) -> Bool {
+        guard let resolved = resolved else { return false }
+        return resolved != requested
+    }
+
+    /// Answers on the main queue, cached for the session.
+    static func checkAvailability(of url: URL, completion: @escaping (Bool) -> Void) {
+        if let cached = cacheQueue.sync(execute: { availabilityCache[url] }) {
+            DispatchQueue.main.async { completion(cached) }
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "HEAD"
+        URLSession.shared.dataTask(with: request) { _, response, _ in
+            let available = isRecording(requested: url, resolved: response?.url)
+            cacheQueue.sync { availabilityCache[url] = available }
+            DispatchQueue.main.async { completion(available) }
+        }.resume()
+    }
+
+}

--- a/riidaa/Utils/PageImageServer.swift
+++ b/riidaa/Utils/PageImageServer.swift
@@ -1,0 +1,174 @@
+//
+//  PageImageServer.swift
+//  riidaa
+//
+
+import Foundation
+import Network
+import UIKit
+
+/// Serves one image over loopback so AnkiMobile can fetch it.
+///
+/// AnkiMobile only takes media as a URL it downloads itself. Word audio already lives on the
+/// web; a manga page exists only on this device, so it is published briefly at
+/// `http://127.0.0.1:<port>/<token>.jpg`. Nothing leaves the phone. A background task is held
+/// while the listener runs, since opening AnkiMobile suspends riidaa.
+final class PageImageServer {
+
+    static let shared = PageImageServer()
+
+    private var listener: NWListener?
+    private var payload: Data?
+    private var path: String?
+    private var backgroundTask: UIBackgroundTaskIdentifier = .invalid
+    private var shutdownWork: DispatchWorkItem?
+    private let queue = DispatchQueue(label: "dev.repierre.riidaa.pageimage")
+
+    private init() {}
+
+    /// Readiness and the timeout can race
+    private final class ResumeOnce {
+        private var done = false
+        private let lock = NSLock()
+
+        func resume(_ continuation: CheckedContinuation<NWEndpoint.Port?, Never>, with value: NWEndpoint.Port?) {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !done else { return }
+            done = true
+            continuation.resume(returning: value)
+        }
+    }
+
+    /// Returns the URL for the Anki field, or nil if the listener could not start.
+    func publish(_ image: UIImage, quality: CGFloat = 0.8, duration: TimeInterval = 60) async -> URL? {
+        guard let data = image.jpegData(compressionQuality: quality) else { return nil }
+
+        stop()
+
+        let token = UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(16)
+        let path = "/\(token).jpg"
+
+        guard let listener = try? NWListener(using: .tcp, on: .any) else { return nil }
+        queue.sync {
+            self.payload = data
+            self.path = path
+        }
+        self.listener = listener
+
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.serve(connection)
+        }
+
+        let port: NWEndpoint.Port? = await withCheckedContinuation { continuation in
+            let guardian = ResumeOnce()
+            listener.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    guardian.resume(continuation, with: listener.port)
+                case .failed(let error):
+                    print("PageImageServer failed: \(error)")
+                    guardian.resume(continuation, with: nil)
+                case .waiting:
+                    // Transient; the timeout below covers a listener that never recovers.
+                    break
+                case .cancelled:
+                    guardian.resume(continuation, with: nil)
+                default:
+                    break
+                }
+            }
+            queue.asyncAfter(deadline: .now() + 5) {
+                guardian.resume(continuation, with: nil)
+            }
+            listener.start(queue: queue)
+        }
+
+        guard let port = port else {
+            stop()
+            return nil
+        }
+
+        beginBackgroundTask()
+        scheduleShutdown(after: duration)
+        return URL(string: "http://127.0.0.1:\(port.rawValue)\(path)")
+    }
+
+    func stop() {
+        shutdownWork?.cancel()
+        shutdownWork = nil
+        listener?.cancel()
+        listener = nil
+        queue.sync {
+            payload = nil
+            path = nil
+        }
+        endBackgroundTask()
+    }
+
+    private func serve(_ connection: NWConnection) {
+        connection.start(queue: queue)
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 8192) { [weak self] data, _, _, _ in
+            guard let self = self else {
+                connection.cancel()
+                return
+            }
+            let request = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+            let response = self.response(for: request)
+            connection.send(content: response, isComplete: true, completion: .contentProcessed { _ in
+                self.queue.asyncAfter(deadline: .now() + 1) {
+                    connection.cancel()
+                }
+            })
+        }
+    }
+
+    private func response(for request: String) -> Data {
+        // Only the published path is served.
+        guard let path = path, let payload = payload,
+              let line = request.split(separator: "\r\n").first,
+              line.contains(" \(path) ") else {
+            return Data("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".utf8)
+        }
+
+        var response = Data("""
+        HTTP/1.1 200 OK\r
+        Content-Type: image/jpeg\r
+        Content-Length: \(payload.count)\r
+        Cache-Control: no-store\r
+        Connection: close\r
+        \r\n
+        """.utf8)
+        response.append(payload)
+        return response
+    }
+
+    private func beginBackgroundTask() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.endBackgroundTaskOnMain()
+            self.backgroundTask = UIApplication.shared.beginBackgroundTask(withName: "riidaa.pageimage") { [weak self] in
+                self?.stop()
+            }
+        }
+    }
+
+    private func endBackgroundTask() {
+        DispatchQueue.main.async { [weak self] in
+            self?.endBackgroundTaskOnMain()
+        }
+    }
+
+    private func endBackgroundTaskOnMain() {
+        guard backgroundTask != .invalid else { return }
+        UIApplication.shared.endBackgroundTask(backgroundTask)
+        backgroundTask = .invalid
+    }
+
+    private func scheduleShutdown(after duration: TimeInterval) {
+        let work = DispatchWorkItem { [weak self] in self?.stop() }
+        shutdownWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: work)
+    }
+
+}

--- a/riidaa/Views/Reader/MangaReader.swift
+++ b/riidaa/Views/Reader/MangaReader.swift
@@ -135,7 +135,7 @@ public struct MangaReader: View {
                 }
                 .onChange(of: currentPage) { newPage in
                     self.currentLine = nil
-                                    if pages[currentPage].read_at == nil {
+                    if pages[currentPage].read_at == nil {
                         pages[currentPage].read_at = NSDate()
                     }
                     volume.lastReadPage = Int64(newPage)
@@ -245,6 +245,7 @@ public struct MangaReader: View {
             source: currentSource,
             pageImage: currentPageImage
         )
+        .padding(.top, 10)
         .presentationDetents([.height(140), .medium, .large])
         .presentationDragIndicator(.visible)
 

--- a/riidaa/Views/Reader/MangaReader.swift
+++ b/riidaa/Views/Reader/MangaReader.swift
@@ -19,11 +19,9 @@ public struct MangaReader: View {
     @State var currentPage: Int
     
     @State private var pages: [MangaPageModel] = []
-    @State private var currentLine: String? = nil
+    @State private var currentLine: SelectedLine? = nil
     
-    @State private var parserOffset: CGFloat = 0
     @State private var menuVisible = false
-    @GestureState private var dragOffset: CGFloat = 0
     @State private var pageHeight = 0.0
     @State private var ready = false
     
@@ -32,7 +30,19 @@ public struct MangaReader: View {
     private var displayedPages: [MangaPageModel] {
         settings.isLTR ? pages : pages.reversed()
     }
-    
+
+    /// The rendered page the open line sits on, for the Anki `picture` field. Resolved on
+    /// demand so tapping a word never decodes an image that no one exports.
+    private func currentPageImage() -> UIImage? {
+        guard let currentLine = currentLine else { return nil }
+        return pages.first { $0.number == currentLine.page }?.getImage()
+    }
+
+    private var currentSource: MangaSource? {
+        guard let currentLine = currentLine else { return nil }
+        return MangaSource(title: volume.manga.title, volume: volume.number, page: currentLine.page)
+    }
+
     
     var isDualPage: Bool {
                 UIDevice.current.userInterfaceIdiom == .pad && (UIDevice.current.orientation == .landscapeLeft || UIDevice.current.orientation == .landscapeRight)
@@ -49,18 +59,26 @@ public struct MangaReader: View {
         }
     }
     
-    func parserHeight(minHeight: CGFloat, maxHeight: CGFloat) -> CGFloat {
-        max(min(minHeight + parserOffset-dragOffset, maxHeight), minHeight)
+    private func tag(for page: MangaPageModel) -> Int {
+        if isDualPage {
+            return Int(page.number) - (settings.isLTR ? 1 : 2)
+        }
+        return Int(page.number) - 1
     }
-    
-    
+
+    /// Turns the page for a swipe that ran out of room on a zoomed image.
+    private func turnPage(_ edge: ZoomEdgeSwipe) {
+        guard let index = displayedPages.firstIndex(where: { tag(for: $0) == currentPage }) else {
+            return
+        }
+        let step = (isDualPage ? 2 : 1) * (edge == .trailing ? 1 : -1)
+        let target = index + step
+        guard displayedPages.indices.contains(target) else { return }
+        currentPage = tag(for: displayedPages[target])
+    }
+
     public var body: some View {
         GeometryReader { mainGeom in
-            let minHeight = CGFloat(100)//min(mainGeom.size.height * 0.2, max(mainGeom.size.height * 0.1, mainGeom.size.height - pageHeight))
-            let maxHeight = mainGeom.size.height * 0.8
-            let tHeight1 = (maxHeight + minHeight)/3
-            let tHeight2 = 2 * tHeight1
-            
             ZStack(alignment: .bottom) {
                 TabView(selection: .init(get: {
                     if isDualPage {
@@ -87,7 +105,7 @@ public struct MangaReader: View {
                                     pageDisplay(index: index)
                                 }
                             }
-                            .zoomable()
+                            .zoomable(onEdgeSwipe: turnPage)
                             .onTapGesture(count: 1) {
                                 menuVisible.toggle()
                             }
@@ -102,7 +120,7 @@ public struct MangaReader: View {
                             VStack {
                                 pageDisplay(index: index)
                             }
-                            .zoomable()
+                            .zoomable(onEdgeSwipe: turnPage)
                             .onTapGesture(count: 1) {
                                 menuVisible.toggle()
                             }
@@ -117,8 +135,7 @@ public struct MangaReader: View {
                 }
                 .onChange(of: currentPage) { newPage in
                     self.currentLine = nil
-                    self.parserOffset = 0
-                    if pages[currentPage].read_at == nil {
+                                    if pages[currentPage].read_at == nil {
                         pages[currentPage].read_at = NSDate()
                     }
                     volume.lastReadPage = Int64(newPage)
@@ -138,15 +155,12 @@ public struct MangaReader: View {
                 .animation(.easeInOut(duration: 0.25), value: menuVisible)
                 .zIndex(2)
 
-                VStack(spacing: 0) {
-                    Spacer(minLength: 0)
-                    if currentLine != nil {
-                        dictPanel(minHeight: minHeight, maxHeight: maxHeight, tHeight1: tHeight1, tHeight2: tHeight2)
-                            .transition(.move(edge: .bottom))
-                    }
-                }
-                .animation(.easeInOut(duration: 0.25), value: currentLine)
-                .zIndex(1)
+            }
+            .sheet(isPresented: Binding(
+                get: { currentLine != nil },
+                set: { presented in if !presented { currentLine = nil } }
+            )) {
+                lookupSheet
             }
         }
         .statusBarHidden(!menuVisible)
@@ -223,44 +237,26 @@ public struct MangaReader: View {
         .background(.ultraThinMaterial)
     }
 
+    /// The lookup panel, as a system sheet.
     @ViewBuilder
-    private func dictPanel(minHeight: CGFloat, maxHeight: CGFloat, tHeight1: CGFloat, tHeight2: CGFloat) -> some View {
-        VStack(alignment: .center, spacing: 0) {
-            Capsule()
-                .frame(width: 50, height: 6)
-                .foregroundColor(.gray)
-                .padding(.top, 5)
-                .padding(.bottom, 5)
-
-            MangaReaderParserView(line: currentLine ?? "")
-                .frame(maxWidth: .infinity)
-        }
-        .frame(height: parserHeight(minHeight: minHeight, maxHeight: maxHeight), alignment: .bottom)
-        .background(Color(.systemGray6))
-        .roundedCorners(20, corners: [.topLeft, .topRight])
-        .gesture(
-            DragGesture(coordinateSpace: .global)
-                .updating($dragOffset) { value, state, tr in
-                    state = value.translation.height
-                }
-                .onEnded { value in
-                    if minHeight + parserOffset-value.translation.height > tHeight2 {
-                        parserOffset = maxHeight - minHeight
-                    } else if minHeight + parserOffset-value.translation.height < tHeight1 || value.translation.height > 0 {
-                        if parserOffset == 0 && value.translation.height > 60 {
-                            currentLine = nil
-                        } else {
-                            parserOffset = 0
-                        }
-                    } else {
-                        parserOffset = maxHeight - minHeight
-                    }
-                }
+    private var lookupSheet: some View {
+        let content = MangaReaderParserView(
+            line: currentLine?.text ?? "",
+            source: currentSource,
+            pageImage: currentPageImage
         )
-        .animation(.easeIn(duration: 0.15), value: parserOffset)
+        .presentationDetents([.height(140), .medium, .large])
+        .presentationDragIndicator(.visible)
+
+        if #available(iOS 16.4, *) {
+            content
+                .presentationBackgroundInteraction(.enabled(upThrough: .medium))
+                .presentationContentInteraction(.scrolls)
+        } else {
+            content
+        }
     }
 
-    
     @ViewBuilder
     public func pageDisplay(index: Int) -> some View {
         let page = displayedPages[index]
@@ -290,7 +286,7 @@ public struct MangaReader: View {
                         .resizable()
                         .scaledToFit()
                 }
-                MangaReaderBoxes(boxes: page.getBoxes(), scale: scale, offsetX: offsetX, offsetY: offsetY, currentLine: $currentLine)
+                MangaReaderBoxes(boxes: page.getBoxes(), pageNumber: page.number, scale: scale, offsetX: offsetX, offsetY: offsetY, currentLine: $currentLine)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
             .onAppear {
@@ -350,10 +346,10 @@ public struct MangaReader: View {
                         .resizable()
                         .scaledToFit()
                 }
-                MangaReaderBoxes(boxes: page1.getBoxes(), scale: scale1, offsetX: offsetX1, offsetY: offsetY1, currentLine: $currentLine)
+                MangaReaderBoxes(boxes: page1.getBoxes(), pageNumber: page1.number, scale: scale1, offsetX: offsetX1, offsetY: offsetY1, currentLine: $currentLine)
                     .frame(width: halfWidth)
                     .offset(x: -offsetX1)
-                MangaReaderBoxes(boxes: page2.getBoxes(), scale: scale2, offsetX: offsetX2, offsetY: offsetY2, currentLine: $currentLine)
+                MangaReaderBoxes(boxes: page2.getBoxes(), pageNumber: page2.number, scale: scale2, offsetX: offsetX2, offsetY: offsetY2, currentLine: $currentLine)
                     .offset(x: offsetX2)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)

--- a/riidaa/Views/Reader/MangaReaderBoxes.swift
+++ b/riidaa/Views/Reader/MangaReaderBoxes.swift
@@ -7,17 +7,23 @@
 
 import SwiftUI
 
+struct SelectedLine: Equatable {
+    let text: String
+    let page: Int64
+}
+
 struct MangaReaderBoxes: View {
-    
+
     @EnvironmentObject var settings: SettingsModel
-    
+
     var boxes: [PageBoxModel]
+    var pageNumber: Int64
     var scale: Double
     var offsetX: Double
     var offsetY: Double
-    
-    @Binding var currentLine: String?
-    
+
+    @Binding var currentLine: SelectedLine?
+
     var body: some View {
         ForEach(boxes, id: \.self) { box in
             ZStack {
@@ -40,7 +46,7 @@ struct MangaReaderBoxes: View {
             )
             .rotationEffect(Angle(degrees: box.rotation))
             .highPriorityGesture(SpatialTapGesture(count: 1).onEnded { _ in
-                currentLine = box.text
+                currentLine = SelectedLine(text: box.text, page: pageNumber)
             })
         }
     }

--- a/riidaa/Views/Reader/MangaReaderParserView.swift
+++ b/riidaa/Views/Reader/MangaReaderParserView.swift
@@ -6,10 +6,13 @@
 //
 
 import SwiftUI
+import AVFoundation
 
 struct MangaReaderParserView: View {
     
     let line: String
+    var source: MangaSource? = nil
+    var pageImage: (() -> UIImage?)? = nil
     @State var parsedText: [ParsingResult] = []
     @State var selectedElement: Int?
     @State var loading = false
@@ -68,7 +71,7 @@ struct MangaReaderParserView: View {
                             ScrollView(showsIndicators: false) {
                                 LazyVStack(alignment: .leading) {
                                     ForEach(parsedText[selectedElement].results, id: \.self) { result in
-                                        ResultView(result: result, fullSentence: line, definition: $inflectionDescription)
+                                        ResultView(result: result, fullSentence: line, source: source, match: sentenceMatch(at: selectedElement), pageImage: pageImage, definition: $inflectionDescription)
                                     }
                                 }
                             }
@@ -106,7 +109,14 @@ struct MangaReaderParserView: View {
 }
 
 extension MangaReaderParserView {
-    
+
+    /// Where the selected token sits in the line
+    func sentenceMatch(at index: Int) -> SentenceMatch? {
+        guard parsedText.indices.contains(index) else { return nil }
+        let offset = parsedText[..<index].reduce(0) { $0 + $1.original.count }
+        return SentenceMatch(surface: parsedText[index].original, offset: offset)
+    }
+
     func parseLine(line: String) {
         DispatchQueue.global(qos: .userInteractive).async {
             self.loading = true
@@ -210,61 +220,55 @@ extension MangaReaderParserView {
 
 
 struct ResultView: View {
-    @State var result: TermDeinflection
-    @State var fullSentence: String
-    
+    var result: TermDeinflection
+    var fullSentence: String
+    var source: MangaSource? = nil
+    var match: SentenceMatch? = nil
+    var pageImage: (() -> UIImage?)? = nil
+
     @Binding var definition: InflectionDescription?
     @EnvironmentObject var settings: SettingsModel
+
+    @State private var meta: [TermMetaDB] = []
+    @State private var audioPlayer: AVPlayer? = nil
+    @State private var audioAvailable = false
+
+    /// Nil unless a real recording exists
+    private var audioURL: URL? {
+        guard settings.wordAudioEnabled, audioAvailable else { return nil }
+        return WordAudio.url(term: result.term.term, reading: result.term.reading)
+    }
+
+    private var summary: TermMetaSummary {
+        TermMetaSummary(meta: meta, reading: result.term.reading)
+    }
     
     var body: some View {
         VStack(alignment: .leading) {
             HStack {
                 Text("\(result.term.term) (\(result.term.reading))")
                     .font(.title)
+                if let audioURL = audioURL {
+                    Button {
+                        play(audioURL)
+                    } label: {
+                        Image(systemName: "speaker.wave.2.fill")
+                            .font(.title3)
+                    }
+                    .accessibilityLabel("Play pronunciation")
+                }
                 Spacer()
                 
-                Button("Export") {
-                    guard
-                        let profileName = settings.ankiProfile?.name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-                        let noteTypeName = settings.ankiNoteType?.name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-                        let deckName = settings.ankiDeck?.name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
-                        return
+                if settings.ankiExport != nil {
+                    Button("Export") {
+                        Task { await export() }
                     }
-                    
-                    var fields = ""
-                    
-                    if let fieldWord = settings.ankiFieldWord, let fieldWorldEncoded = fieldWord.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-                       let wordEncoded = result.term.term.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
-                        fields += "&fld\(fieldWorldEncoded)=\(wordEncoded)"
-                    }
-                    if let fieldReading = settings.ankiFieldReading, let fieldReadingEncoded = fieldReading.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-                       let readingEncoded = result.term.reading.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
-                        fields += "&fld\(fieldReadingEncoded)=\(readingEncoded)"
-                    }
-                    if let fieldMeaning = settings.ankiFieldMeaning, let fieldMeaningEncoded = fieldMeaning.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-                       let firstMeaning = result.term.parseDefinition.first,
-                       let meaningEncoded = firstMeaning.description.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
-                        fields += "&fld\(fieldMeaningEncoded)=\(meaningEncoded)"
-                    }
-                    if let fieldExample = settings.ankiFieldExample, let fieldExampleEncoded = fieldExample.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-                       let exampleEncoded = fullSentence.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
-                        fields += "&fld\(fieldExampleEncoded)=\(exampleEncoded)"
-                    }
-                    
-                    if fields.isEmpty {
-                        return
-                    }
-                    guard
-                        let url = URL(string: "anki://x-callback-url/addnote?profile=\(profileName)&deck=\(deckName)&type=\(noteTypeName)&x-success=\("riidaa://anki-callback?term=\(result.term.hashValue)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")\(fields)") else {
-                        return
-                    }
-                    UIApplication.shared.open(url, options: [:])
+                    .padding(.vertical, 7)
+                    .padding(.horizontal, 10)
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(7)
                 }
-                .padding(.vertical, 7)
-                .padding(.horizontal, 10)
-                .background(Color.blue)
-                .foregroundColor(.white)
-                .cornerRadius(7)
                 
             }
             ForEach(result.deinflections, id: \.inflections) { deinflection in
@@ -307,9 +311,49 @@ struct ResultView: View {
                     .background(Color.purple)
                     .roundedCorners(5, corners: .allCorners)
             }
+            if !summary.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack {
+                        ForEach(summary.pitchPositions, id: \.self) { position in
+                            Text(position)
+                                .font(.footnote)
+                                .padding(.horizontal, 7)
+                                .padding(.vertical, 4)
+                                .background(Color.orange)
+                                .roundedCorners(5, corners: .allCorners)
+                        }
+                        ForEach(summary.frequencyLabels, id: \.self) { label in
+                            Text(label)
+                                .font(.footnote)
+                                .padding(.horizontal, 7)
+                                .padding(.vertical, 4)
+                                .background(Color.green)
+                                .roundedCorners(5, corners: .allCorners)
+                        }
+                    }
+                }
+            }
             TermDefinitionsView(term: result.term)
 
-        }.onOpenURL { url in
+        }
+        .onAppear {
+            let term = result.term
+            if settings.wordAudioEnabled, let candidate = WordAudio.url(term: term.term, reading: term.reading) {
+                WordAudio.checkAvailability(of: candidate) { available in
+                    self.audioAvailable = available
+                }
+            }
+            DispatchQueue.global(qos: .userInitiated).async {
+                let found = SQLiteManager.shared.findTermMeta(texts: [term.term, term.reading])
+                DispatchQueue.main.async {
+                    self.meta = found
+                }
+            }
+        }
+        .onOpenURL { url in
+            if url.scheme == "riidaa", url.host() == "anki-callback" {
+                PageImageServer.shared.stop()
+            }
             guard url.scheme == "riidaa",
                   url.host() == "anki-callback",
                   let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
@@ -322,6 +366,44 @@ struct ResultView: View {
             }
 
         }
+    }
+
+    /// Async because the loopback listener must be up and its port known before the URL can
+    /// name it.
+    private func export() async {
+        guard let export = settings.ankiExport else { return }
+
+        var pictureURL: URL? = nil
+        if export.fields[.picture] != nil, let image = pageImage?() {
+            pictureURL = await PageImageServer.shared.publish(image)
+        }
+
+        let context = AnkiNoteContext(
+            term: result.term,
+            sentence: fullSentence,
+            source: source,
+            match: match,
+            meta: meta,
+            audioURL: audioURL,
+            pictureURL: pictureURL
+        )
+        guard let url = export.addNoteURL(
+            context: context,
+            callback: "riidaa://anki-callback?term=\(result.term.hashValue)"
+        ) else {
+            PageImageServer.shared.stop()
+            return
+        }
+        await UIApplication.shared.open(url, options: [:])
+    }
+
+    /// Playback category so a deliberate tap is audible with the ringer switched off.
+    private func play(_ url: URL) {
+        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+        try? AVAudioSession.sharedInstance().setActive(true)
+        let player = AVPlayer(url: url)
+        audioPlayer = player
+        player.play()
     }
 }
 

--- a/riidaa/Views/Settings/AnkiView.swift
+++ b/riidaa/Views/Settings/AnkiView.swift
@@ -13,113 +13,78 @@ struct AnkiView: View {
     
     var body: some View {
         VStack {
-            VStack(alignment: .leading, spacing: 20) {
-                if let infos = settings.ankiInfo {
-                    HStack {
-                        Text("Choose profile:")
-                            .font(.headline)
-                        
-                        Picker("Profile", selection: $settings.ankiProfile) {
-                            ForEach(infos.profiles) { profile in
-                                Text(profile.name).tag(profile as AnkiInfo.Profile?)
-                            }
-                        }
-                        .pickerStyle(.menu)
-                        Spacer()
-                    }
-                    .padding(.top)
-                    
-                    HStack {
-                        Text("Choose deck:")
-                            .font(.headline)
-                        
-                        Picker("Deck", selection: $settings.ankiDeck) {
-                            ForEach(infos.decks) { deck in
-                                Text(deck.name).tag(deck as AnkiInfo.Deck?)
-                            }
-                        }
-                        .pickerStyle(.menu)
-                        Spacer()
-                    }
-                    
-                    HStack {
-                        Text("Choose format:")
-                            .font(.headline)
-                        
-                        Picker("Format", selection: $settings.ankiNoteType) {
-                            ForEach(infos.notetypes) { noteType in
-                                Text(noteType.name).tag(noteType as AnkiInfo.NoteType?)
-                            }
-                        }
-                        .pickerStyle(.menu)
-                        Spacer()
-                    }
-                    
-                    if let noteType = settings.ankiNoteType {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    if let infos = settings.ankiInfo {
                         HStack {
-                            Text("Choose field for word:")
+                            Text("Choose profile:")
                                 .font(.headline)
-                            
-                            Picker("field", selection: $settings.ankiFieldWord) {
-                                Text("None").tag(nil as String?)
-                                ForEach(noteType.fields) { field in
-                                    Text(field.name).tag(field.name as String?)
+
+                            Picker("Profile", selection: $settings.ankiProfile) {
+                                ForEach(infos.profiles) { profile in
+                                    Text(profile.name).tag(profile as AnkiInfo.Profile?)
                                 }
                             }
                             .pickerStyle(.menu)
                             Spacer()
                         }
-                        
+                        .padding(.top)
+
                         HStack {
-                            Text("Choose field for reading:")
+                            Text("Choose deck:")
                                 .font(.headline)
-                            
-                            Picker("field", selection: $settings.ankiFieldReading) {
-                                Text("None").tag(nil as String?)
-                                ForEach(noteType.fields) { field in
-                                    Text(field.name).tag(field.name as String?)
+
+                            Picker("Deck", selection: $settings.ankiDeck) {
+                                ForEach(infos.decks) { deck in
+                                    Text(deck.name).tag(deck as AnkiInfo.Deck?)
                                 }
                             }
                             .pickerStyle(.menu)
                             Spacer()
                         }
-                        
+
                         HStack {
-                            Text("Choose field for meaning:")
+                            Text("Choose format:")
                                 .font(.headline)
-                            
-                            Picker("field", selection: $settings.ankiFieldMeaning) {
-                                Text("None").tag(nil as String?)
-                                ForEach(noteType.fields) { field in
-                                    Text(field.name).tag(field.name as String?)
+
+                            Picker("Format", selection: $settings.ankiNoteType) {
+                                ForEach(infos.notetypes) { noteType in
+                                    Text(noteType.name).tag(noteType as AnkiInfo.NoteType?)
                                 }
                             }
                             .pickerStyle(.menu)
                             Spacer()
                         }
-                        
-                        HStack {
-                            Text("Choose field for sentence:")
-                                .font(.headline)
-                            
-                            Picker("field", selection: $settings.ankiFieldExample) {
-                                Text("None").tag(nil as String?)
-                                ForEach(noteType.fields) { field in
-                                    Text(field.name).tag(field.name as String?)
+
+                        if let noteType = settings.ankiNoteType {
+                            Button {
+                                settings.autoMapAnkiFields(for: noteType)
+                            } label: {
+                                Label("Match fields automatically", systemImage: "wand.and.stars")
+                            }
+                            .buttonStyle(.bordered)
+
+                            ForEach(AnkiFieldToken.allCases) { token in
+                                HStack {
+                                    Text("Choose field for \(token.label):")
+                                        .font(.headline)
+
+                                    Picker("field", selection: settings.ankiFieldBinding(for: token)) {
+                                        Text("None").tag(nil as String?)
+                                        ForEach(noteType.fields) { field in
+                                            Text(field.name).tag(field.name as String?)
+                                        }
+                                    }
+                                    .pickerStyle(.menu)
+                                    Spacer()
                                 }
                             }
-                            .pickerStyle(.menu)
-                            Spacer()
                         }
                     }
-                    
                 }
-                Spacer()
-                
-                
+                .padding()
             }
-            .padding()
-            
+
             Button("Refresh Anki informations") {
                 fetchAnkiDecks()
             }

--- a/riidaa/Views/Settings/DictionariesView.swift
+++ b/riidaa/Views/Settings/DictionariesView.swift
@@ -12,19 +12,47 @@ struct DictionariesView: View {
     
     @EnvironmentObject var appManager: AppManager
     @State private var isPickingDictionary = false
-    @State private var processingStatus = ProcessingStatus.NOTHING
-    @State private var processingMessage: String = "Processing dictionary..."
-    @State private var processingProgress: Int = 0
-    @State private var processingProgressMax: Int = 0
-    
-    private var dismissDisabled: Bool {
-        return processingStatus == ProcessingStatus.STARTED
-    }
     
     var body: some View {
         ScrollView {
-            ForEach($appManager.dictionaries) { dictionary in
-                DictionaryView(dictionary: dictionary.wrappedValue)
+            if let preparing = appManager.preparing {
+                HStack(spacing: 10) {
+                    ProgressView()
+                    Text(preparing.message)
+                        .font(.subheadline)
+                    Spacer()
+                }
+                .padding()
+                .background(Color(.systemGray6))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                .padding(.top, 8)
+            }
+
+            if let purging = appManager.purging {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Clearing deleted dictionary")
+                            .font(.subheadline)
+                        Spacer()
+                        Text("\(Int(purging.fraction * 100))%")
+                            .font(.subheadline.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                    ProgressView(value: purging.fraction)
+                    Text("\((purging.total - purging.cleared).formatted()) entries left. Lookups keep working while this finishes.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding()
+                .background(Color(.systemGray6))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                .padding(.top, 8)
+            }
+
+            ForEach(appManager.dictionaries) { dictionary in
+                DictionaryView(dictionary: dictionary, onUpdate: updateDictionary)
             }
         }
         .navigationTitle("Dictionaries")
@@ -36,10 +64,6 @@ struct DictionariesView: View {
             }
         }
         .fileImporter(isPresented: $isPickingDictionary, allowedContentTypes: [.zip]) { result in
-            self.processingMessage = "Processing dictionary..."
-            self.processingStatus = ProcessingStatus.STARTED
-            self.processingProgress = 0
-            self.processingProgressMax = 0
             switch result {
             case .success(let file):
                 processZipFile(path: file)
@@ -47,66 +71,91 @@ struct DictionariesView: View {
                 print("error while picking dictionary file: \(error)")
             }
         }
-        .sheet(
-            isPresented: .init(get: {
-                return self.processingStatus != ProcessingStatus.NOTHING
-            }, set: { _ in }),
-            onDismiss: {
-                if self.processingStatus != ProcessingStatus.STARTED {
-                    self.processingStatus = ProcessingStatus.NOTHING
+        .alert(
+            "Dictionary error",
+            isPresented: Binding(
+                get: { appManager.lastError != nil },
+                set: { shown in if !shown { appManager.lastError = nil } }
+            ),
+            actions: { Button("OK", role: .cancel) {} },
+            message: { Text(appManager.lastError ?? "") }
+        )
+    }
+
+    /// Downloads `downloadUrl` and re-imports it, replacing the existing copy.
+    func updateDictionary(_ dictionary: DictionaryDB) {
+        guard let downloadUrl = dictionary.downloadUrl, let url = URL(string: downloadUrl) else {
+            appManager.report(error: "This dictionary does not publish a download link.")
+            return
+        }
+
+        let replacing = dictionary.id
+        appManager.setProgress(DictionaryProgress(message: "Downloading…", value: 0, total: 0), for: replacing)
+
+        Task {
+            do {
+                let (temporary, _) = try await URLSession.shared.download(from: url)
+                // The importer keys off the extension, and a download has none.
+                let archive = temporary.deletingPathExtension().appendingPathExtension("zip")
+                try? FileManager.default.removeItem(at: archive)
+                try FileManager.default.moveItem(at: temporary, to: archive)
+
+                await MainActor.run {
+                    self.processZipFile(path: archive, securityScoped: false, replacing: replacing)
                 }
+            } catch {
+                appManager.setProgress(nil, for: replacing)
+                appManager.report(error: "Download failed: \(error.localizedDescription)")
             }
-        ) {
-            VStack{
-                VStack(spacing: 40) {
-                    switch processingStatus {
-                    case .STARTED:
-                        CircularProgressView(progress: self.processingProgress, progressMax: self.processingProgressMax)
-                            .frame(width: 150, height: 150)
-//                        Text("\(processingProgress) / \(processingProgressMax)")
-                        
-                    case .FINISHED:
-                        Image(systemName: "checkmark")
-                            .scaleEffect(4)
-                            .frame(width: 150, height: 150)
-                    case .ERROR:
-                        Image(systemName: "xmark")
-                            .scaleEffect(4)
-                            .frame(width: 150, height: 150)
-                    case .NOTHING:
-                        EmptyView()
-                    }
-                    Text(processingMessage)
-                        .font(.largeTitle)
-                        .multilineTextAlignment(.center)
-                        .padding()
-                    
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
-            .interactiveDismissDisabled(dismissDisabled)
         }
     }
-    
-    func processZipFile(path: URL) {
+
+    func processZipFile(path: URL, securityScoped: Bool = true, replacing: Int64? = nil) {
+        // Snapshot taken here
+        let installedSnapshot = appManager.dictionaries
         DispatchQueue.global(qos: .userInitiated).async {
             let fileManager = FileManager.default
             let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("dictionaries")
             let dicDirectory = documents.appendingPathComponent(UUID().uuidString)
-            
+
+            // Progress goes to AppManager, which outlives this screen.
+            var done = 0
+            var total = 0
+            var reportingId: Int64? = replacing
+            func report(_ message: String) {
+                appManager.setProgress(
+                    DictionaryProgress(message: message, value: done, total: total),
+                    for: reportingId
+                )
+            }
+
+            // Nothing reads these again once they are in SQLite; jitendex unpacks to 500 MB.
+            defer {
+                try? fileManager.removeItem(at: dicDirectory)
+                if !securityScoped {
+                    // riidaa downloaded this one, so it owns the file too.
+                    try? fileManager.removeItem(at: path)
+                }
+            }
+
             do {
-                if !path.startAccessingSecurityScopedResource() {
+                let scoped = securityScoped && path.startAccessingSecurityScopedResource()
+                if securityScoped && !scoped {
                     throw NSError(domain: "DictionaryImport", code: 0, userInfo: [NSLocalizedDescriptionKey: "Permission denied"])
                 }
                 defer {
-                    path.stopAccessingSecurityScopedResource()
+                    if scoped {
+                        path.stopAccessingSecurityScopedResource()
+                    }
                 }
                 
+                report("Unpacking…")
                 try fileManager.createDirectory(at: dicDirectory, withIntermediateDirectories: true)
                 try fileManager.unzipItem(at: path, to: dicDirectory)
                 
                 let dicContent = try fileManager.contentsOfDirectory(at: dicDirectory, includingPropertiesForKeys: nil)
-                self.processingProgressMax = (dicContent.count)
+                total = dicContent.count
+                report("Processing dictionary…")
                 
                 guard let fileContent = try? Data(contentsOf: dicDirectory.appendingPathComponent("index.json")) else {
                     throw NSError(domain: "DictionaryImport", code: 1, userInfo: [NSLocalizedDescriptionKey: "Could not find dictionary index.json"])
@@ -132,17 +181,59 @@ struct DictionariesView: View {
                 let sourceLanguage = dicJson["sourceLanguage"] as? String
                 let targetLanguage = dicJson["targetLanguage"] as? String
                 let frequencyMode = dicJson["frequencyMode"] as? String
+
+                let alreadyInstalled = installedSnapshot.first { existing in
+                    if existing.id == replacing { return false }
+                    if let indexUrl = indexUrl, let other = existing.indexUrl, !indexUrl.isEmpty {
+                        return other == indexUrl
+                    }
+                    return existing.title == title
+                }
+                if let existing = alreadyInstalled {
+                    let action = replacing == nil
+                        ? "Use Update on it instead, or delete it first."
+                        : "Delete one of them first."
+                    throw NSError(domain: "DictionaryImport", code: 4, userInfo: [
+                        NSLocalizedDescriptionKey: existing.revision == revision
+                            ? "\(existing.title) is already installed."
+                            : "\(existing.title) is already installed (revision \(existing.revision)). \(action)"
+                    ])
+                }
+
                 
-                guard let dictionary = SQLiteManager.shared.insertDictionary(revision: revision, title: title, sequenced: sequenced ?? false, format: format ?? 3, author: author, isUpdatable: isUpdatable ?? false, indexUrl: indexUrl, downloadUrl: downloadUrl, url: url, description: description, attribution: attribution, sourceLanguage: sourceLanguage, targetLanguage: targetLanguage, frequencyMode: frequencyMode) else {
+                var installed: DictionaryDB? = nil
+                // Any throw past this point must take the row with it, or a half-imported
+                // dictionary stays installed and feeds partial results into every lookup.
+                defer {
+                    if let installed = installed {
+                        try? SQLiteManager.shared.deleteDictionary(dictionaryId: installed.id)
+                        DispatchQueue.main.async {
+                            appManager.dictionaries.removeAll { $0.id == installed.id }
+                        }
+                        appManager.purgeOrphanedEntries()
+                    }
+                }
+
+                let dictionaryOrNil = SQLiteManager.shared.insertDictionary(revision: revision, title: title, sequenced: sequenced ?? false, format: format ?? 3, author: author, isUpdatable: isUpdatable ?? false, indexUrl: indexUrl, downloadUrl: downloadUrl, url: url, description: description, attribution: attribution, sourceLanguage: sourceLanguage, targetLanguage: targetLanguage, frequencyMode: frequencyMode)
+                guard let dictionary = dictionaryOrNil else {
                     throw NSError(domain: "DictionaryImport", code: 2, userInfo: [NSLocalizedDescriptionKey: "Error saving dictionary"])
                 }
-                
-                
-                DispatchQueue.main.async {
-                    self.processingProgress += 1
+                installed = dictionary
+                // An update keeps reporting against the row the user can see
+                if replacing == nil {
+                    reportingId = dictionary.id
+                    DispatchQueue.main.async { appManager.dictionaries.append(dictionary) }
                 }
+                report("Importing…")
                 
                 
+                done += 1
+                report("Processing dictionary…")
+                
+                
+                var importedTerms = 0
+                var importedMeta = 0
+
                 var i = 1
                 while true {
                     
@@ -177,24 +268,85 @@ struct DictionariesView: View {
                         guard SQLiteManager.shared.insertTerms(termsInsert: insertTerms) != nil else {
                             throw NSError(domain: "DictionaryImport", code: 2, userInfo: [NSLocalizedDescriptionKey: "Error saving terms"])
                         }
+                        importedTerms += insertTerms.count
                         
                         i += 1
                         
-                        DispatchQueue.main.async {
-                            self.processingProgress += 1
-                        }
+                        done += 1
+                        report("Processing dictionary…")
                     }
                 }
-                
-                DispatchQueue.main.async {
-                    appManager.dictionaries.append(dictionary)
-                    self.processingProgress = self.processingProgressMax
-                    self.processingMessage = "Dictionary processed."
-                    self.processingStatus = ProcessingStatus.FINISHED
+
+                // Pitch and frequency dictionaries ship no term_bank files at all.
+                var m = 1
+                while true {
+                    let filename = "term_meta_bank_\(m).json"
+                    let filepath = dicDirectory.appending(component: filename)
+
+                    guard let fileContent = try? Data(contentsOf: filepath) else {
+                        break
+                    }
+                    try autoreleasepool {
+                        let metaJson = try? JSONSerialization.jsonObject(with: fileContent)
+                        guard let metaJson = metaJson as? [[Any]] else {
+                            throw NSError(domain: "DictionaryImport", code: 2, userInfo: [NSLocalizedDescriptionKey: "Error decoding term metadata"])
+                        }
+                        let insertMeta: [TermMetaInsertion] = metaJson.compactMap({ t in
+                            guard t.count >= 3,
+                                  let term = t[0] as? String,
+                                  let mode = t[1] as? String,
+                                  let parsed = TermMetaParser.parse(mode: mode, data: t[2]),
+                                  let dataEncoded = try? JSONSerialization.data(withJSONObject: t[2], options: [.fragmentsAllowed])
+                            else {
+                                return nil
+                            }
+                            return TermMetaInsertion(term: term, reading: parsed.reading, mode: mode, data: dataEncoded, dictionaryId: dictionary.id)
+                        })
+                        guard SQLiteManager.shared.insertTermMeta(metaInsert: insertMeta) != nil else {
+                            throw NSError(domain: "DictionaryImport", code: 2, userInfo: [NSLocalizedDescriptionKey: "Error saving term metadata"])
+                        }
+                        importedMeta += insertMeta.count
+
+                        m += 1
+
+                        done += 1
+                        report("Processing dictionary…")
+                    }
                 }
+
+                if i == 1 && m == 1 {
+                    throw NSError(domain: "DictionaryImport", code: 3, userInfo: [NSLocalizedDescriptionKey: "This dictionary contains no term or metadata banks."])
+                }
+                
+                var summary: [String] = []
+                if importedTerms > 0 {
+                    summary.append("\(importedTerms.formatted()) entries")
+                }
+                if importedMeta > 0 {
+                    summary.append("\(importedMeta.formatted()) pitch/frequency entries")
+                }
+                let processedMessage = "Imported \(title)\n\(summary.joined(separator: " and "))."
+
+                // Removed only once the replacement is safely in, so a failed update can't
+                // leave the user with nothing.
+                if let replacing = replacing {
+                    try SQLiteManager.shared.deleteDictionary(dictionaryId: replacing)
+                }
+
+                DispatchQueue.main.async {
+                    if let replacing = replacing {
+                        appManager.dictionaries.removeAll { $0.id == replacing }
+                        appManager.dictionaries.append(dictionary)
+                    }
+                    appManager.setProgress(nil, for: dictionary.id)
+                    appManager.setProgress(nil, for: replacing)
+                }
+                installed = nil
+                print("riidaa: \(processedMessage)")
+                appManager.purgeOrphanedEntries()
             } catch {
-                self.processingStatus = ProcessingStatus.ERROR
-                self.processingMessage = error.localizedDescription
+                appManager.setProgress(nil, for: reportingId)
+                appManager.report(error: error.localizedDescription)
                 return
             }
         }

--- a/riidaa/Views/Settings/DictionaryView.swift
+++ b/riidaa/Views/Settings/DictionaryView.swift
@@ -7,12 +7,26 @@
 
 import SwiftUI
 
+struct DictionaryProgress {
+    let message: String
+    let value: Int
+    let total: Int
+
+    var fraction: Double? {
+        guard total > 0 else { return nil }
+        return min(1, Double(value) / Double(total))
+    }
+}
+
 struct DictionaryView: View {
 
     @ObservedObject var dictionary: DictionaryDB
+    var onUpdate: ((DictionaryDB) -> Void)? = nil
+
     @Environment(\.managedObjectContext) var moc
     @EnvironmentObject var appManager: AppManager
-    @State private var isDeleting = false
+    private var isDeleting: Bool { appManager.deleting.contains(dictionary.id) }
+    private var progress: DictionaryProgress? { appManager.working[dictionary.id] }
 
     var body: some View {
         HStack {
@@ -26,19 +40,35 @@ struct DictionaryView: View {
                     Text("Version: \(dictionary.revision)").font(.subheadline)
                 }
                 Spacer()
-                switch dictionary.hasUpdate {
-                case UpdateState.updateAvailable:
-                    Button("Update") {
-                        print("Updating \(dictionary.title)")
+                if let progress = progress {
+                    VStack(alignment: .trailing, spacing: 4) {
+                        if let fraction = progress.fraction {
+                            ProgressView(value: fraction)
+                                .frame(width: 110)
+                        } else {
+                            ProgressView()
+                                .frame(width: 110)
+                        }
+                        Text(progress.message)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
                     }
-                    .buttonStyle(BorderlessButtonStyle())
-                    .foregroundColor(.blue)
-                case UpdateState.unknown :
-                    ProgressView()
-                        .padding()
-                case UpdateState.upToDate:
-                    Text("Up to date")
+                } else {
+                    switch dictionary.hasUpdate {
+                    case UpdateState.updateAvailable:
+                        Button("Update") {
+                            onUpdate?(dictionary)
+                        }
+                        .buttonStyle(BorderlessButtonStyle())
                         .foregroundColor(.blue)
+                    case UpdateState.unknown :
+                        ProgressView()
+                            .padding()
+                    case UpdateState.upToDate:
+                        Text("Up to date")
+                            .foregroundColor(.blue)
+                    }
                 }
             }
         }
@@ -51,16 +81,7 @@ struct DictionaryView: View {
         }
         .contextMenu {
             Button(role: .destructive) {
-                let dictionaryId = dictionary.id
-                isDeleting = true
-                Task.detached(priority: .utility) {
-                    try? SQLiteManager.shared.deleteDictionary(dictionaryId: dictionaryId)
-                    await MainActor.run {
-                        if let idx = appManager.dictionaries.firstIndex(where: { $0.id == dictionaryId }) {
-                            appManager.dictionaries.remove(at: idx)
-                        }
-                    }
-                }
+                appManager.deleteDictionary(id: dictionary.id)
             } label: {
                 Label("Delete dictionary", systemImage: "trash")
             }

--- a/riidaa/Views/Settings/ReaderSettings.swift
+++ b/riidaa/Views/Settings/ReaderSettings.swift
@@ -15,6 +15,13 @@ struct ReaderSettings: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
                 Toggle("Left to Right Reader", isOn: settings.$isLTR)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Word Audio", isOn: settings.$wordAudioEnabled)
+                    Text("Adds a play button to lookups and an audio value to Anki exports.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
                 
                 
                 Toggle("Use Background Color", isOn: settings.$backgroundColorEnabled)

--- a/riidaa/Views/ZoomableModifier.swift
+++ b/riidaa/Views/ZoomableModifier.swift
@@ -10,9 +10,14 @@
 
 import SwiftUI
 
+public enum ZoomEdgeSwipe {
+    case leading, trailing
+}
+
 struct ZoomableModifier: ViewModifier {
     let minZoomScale: CGFloat
     let doubleTapZoomScale: CGFloat
+    let onEdgeSwipe: ((ZoomEdgeSwipe) -> Void)?
 
     @State private var lastTransform: CGAffineTransform = .identity
     @State private var transform: CGAffineTransform = .identity
@@ -98,9 +103,29 @@ struct ZoomableModifier: ViewModifier {
                     )
                 }
             }
-            .onEnded { _ in
+            .onEnded { value in
+                reportEdgeSwipe(value)
                 onEndGesture()
             }
+    }
+
+    /// A horizontal swipe that began already panned against that side has nowhere to go.
+    private func reportEdgeSwipe(_ value: DragGesture.Value) {
+        guard let onEdgeSwipe = onEdgeSwipe, transform != .identity else { return }
+
+        let horizontal = abs(value.translation.width)
+        guard horizontal > 60, horizontal > abs(value.translation.height) * 1.5 else { return }
+
+        // `lastTransform` is the committed position from before this drag began.
+        let maxX = contentSize.width * (lastTransform.scaleX - 1)
+        let atLeadingEdge = lastTransform.tx >= -0.5
+        let atTrailingEdge = lastTransform.tx <= -maxX + 0.5
+
+        if value.translation.width > 0, atLeadingEdge {
+            onEdgeSwipe(.leading)
+        } else if value.translation.width < 0, atTrailingEdge {
+            onEdgeSwipe(.trailing)
+        }
     }
 
     private func onEndGesture() {
@@ -146,11 +171,13 @@ public extension View {
     @ViewBuilder
     func zoomable(
         minZoomScale: CGFloat = 1,
-        doubleTapZoomScale: CGFloat = 2
+        doubleTapZoomScale: CGFloat = 2,
+        onEdgeSwipe: ((ZoomEdgeSwipe) -> Void)? = nil
     ) -> some View {
         modifier(ZoomableModifier(
             minZoomScale: minZoomScale,
-            doubleTapZoomScale: doubleTapZoomScale
+            doubleTapZoomScale: doubleTapZoomScale,
+            onEdgeSwipe: onEdgeSwipe
         ))
     }
 

--- a/riidaa/riidaaApp.swift
+++ b/riidaa/riidaaApp.swift
@@ -18,17 +18,54 @@ struct riidaaApp: App {
     
     var body: some Scene {
         WindowGroup {
-            if appManager.isLoading {
-                VStack {
-                    ProgressView()
-                    Text("Loading dictionaries")
+            HomeView()
+                .environment(\.managedObjectContext, CoreController.context)
+                .environmentObject(appManager)
+                .environmentObject(settings)
+                .overlay(alignment: .bottom) {
+                    if appManager.isLoading {
+                        DictionaryLoadingBanner(text: "Loading dictionaries…", fraction: nil)
+                            .padding(.bottom, 60)
+                            .transition(.move(edge: .bottom).combined(with: .opacity))
+                    }
                 }
-            } else {
-                HomeView()
-                    .environment(\.managedObjectContext, CoreController.context)
-                    .environmentObject(appManager)
-                    .environmentObject(settings)
-            }
+                .overlay(alignment: .bottom) {
+                    if !appManager.isLoading, let purging = appManager.purging {
+                        DictionaryLoadingBanner(
+                            text: "Clearing deleted dictionary… \(Int(purging.fraction * 100))%",
+                            fraction: purging.fraction
+                        )
+                        .padding(.bottom, 60)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                    }
+                }
+                .animation(.easeInOut(duration: 0.25), value: appManager.isLoading)
+                .animation(.easeInOut(duration: 0.25), value: appManager.purging)
         }
+    }
+}
+
+struct DictionaryLoadingBanner: View {
+    let text: String
+    var fraction: Double? = nil
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if let fraction = fraction {
+                ProgressView(value: fraction)
+                    .frame(width: 60)
+            } else {
+                ProgressView()
+                    .controlSize(.small)
+            }
+            Text(text)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
+        .background(.thinMaterial, in: Capsule())
+        .shadow(radius: 4, y: 2)
+        .accessibilityLabel(text)
     }
 }

--- a/riidaaTests/AnkiExportTests.swift
+++ b/riidaaTests/AnkiExportTests.swift
@@ -116,12 +116,13 @@ struct AnkiExportTests {
 
         let kaishi = AnkiFieldToken.suggestedMapping(
             for: ["Word", "Word Reading", "Word Meaning", "Word Furigana", "Word Audio",
-                  "Sentence", "Notes", "Pitch Accent", "Frequency", "Picture"]
+                  "Sentence", "Sentence Furigana", "Notes", "Pitch Accent", "Frequency", "Picture"]
         )
         #expect(kaishi[.word] == "Word")
         #expect(kaishi[.meaning] == "Word Meaning")
         #expect(kaishi[.pitch] == "Pitch Accent")
         #expect(kaishi[.source] == "Notes")
+        #expect(kaishi[.sentenceFurigana] == "Sentence Furigana")
 
         #expect(AnkiFieldToken.suggestedMapping(for: ["Champ1", "Zzz"]).isEmpty)
     }

--- a/riidaaTests/AnkiExportTests.swift
+++ b/riidaaTests/AnkiExportTests.swift
@@ -110,6 +110,7 @@ struct AnkiExportTests {
         #expect(mapped[.audio] == "ExpressionAudio")
         #expect(mapped[.picture] == "Picture")
         #expect(mapped[.pitch] == "PitchPosition")
+        #expect(mapped[.pitchGraph] == nil)
         #expect(mapped[.frequency] == "Frequency")
         #expect(mapped[.source] == "MiscInfo")
         #expect(Set(mapped.values).count == mapped.count)
@@ -120,7 +121,10 @@ struct AnkiExportTests {
         )
         #expect(kaishi[.word] == "Word")
         #expect(kaishi[.meaning] == "Word Meaning")
-        #expect(kaishi[.pitch] == "Pitch Accent")
+        // A field called "Pitch Accent" wants the diagram; Lapis names its numeric one
+        // "PitchPosition".
+        #expect(kaishi[.pitchGraph] == "Pitch Accent")
+        #expect(kaishi[.pitch] == nil)
         #expect(kaishi[.source] == "Notes")
         #expect(kaishi[.sentenceFurigana] == "Sentence Furigana")
 

--- a/riidaaTests/AnkiExportTests.swift
+++ b/riidaaTests/AnkiExportTests.swift
@@ -1,0 +1,151 @@
+//
+//  AnkiExportTests.swift
+//  riidaaTests
+//
+
+import Foundation
+import Testing
+@testable import riidaa
+
+struct AnkiExportTests {
+
+    private func makeTerm(term: String, reading: String) -> TermDB {
+        TermDB(
+            term: term, reading: reading, definitionTags: [], wordTypes: [], score: 0,
+            definitions: Data(), sequenceNumber: 0, termTags: [],
+            dictionary: DictionaryDB(id: 1, revision: "", title: "Jitendex", format: 3),
+            exportedToAnki: false
+        )
+    }
+
+    private func makeExport(fields: [AnkiFieldToken: String]) -> AnkiExport {
+        AnkiExport(profile: "ユーザー 1", deck: "Mining", noteType: "Lapis", fields: fields)
+    }
+
+    /// Fields AnkiMobile receives, keyed by name (`fldWord=…` → `Word`).
+    private func exportedFields(_ url: URL) -> [String: String] {
+        guard let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems else {
+            return [:]
+        }
+        var fields: [String: String] = [:]
+        for item in items where item.name.hasPrefix("fld") {
+            fields[String(item.name.dropFirst(3))] = item.value ?? ""
+        }
+        return fields
+    }
+
+    @Test func exportsMappedFieldsAndSkipsTheRest() throws {
+        let context = AnkiNoteContext(
+            term: makeTerm(term: "番地", reading: "ばんち"),
+            sentence: "この番地はどこですか",
+            source: MangaSource(title: "よつばと！", volume: 3, page: 42),
+            audioURL: WordAudio.url(term: "番地", reading: "ばんち")
+        )
+        let url = try #require(makeExport(fields: [
+            .word: "Word", .reading: "Word Reading", .furigana: "Word Furigana",
+            .sentence: "Sentence", .source: "Notes", .audio: "Word Audio", .glossary: "Glossary",
+        ]).addNoteURL(context: context, callback: "riidaa://done"))
+        let fields = exportedFields(url)
+
+        #expect(fields["Word"] == "番地")
+        #expect(fields["Word Reading"] == "ばんち")
+        #expect(fields["Word Furigana"] == "番地[ばんち]")
+        #expect(fields["Sentence"] == "この番地はどこですか")
+        #expect(fields["Notes"] == "よつばと！ vol.3 p.42")
+        #expect(fields["Word Audio"]?.hasPrefix("https://assets.languagepod101.com/") == true)
+        // Mapped but with nothing to put in it.
+        #expect(fields["Glossary"] == nil)
+
+        #expect(makeExport(fields: [:]).addNoteURL(context: context, callback: "x") == nil)
+    }
+
+    /// `&`, `=` and `+` in a value used to split it into extra fields, and the callback carries
+    /// its own query string that has to survive as one value.
+    @Test func escapesQueryDelimiters() throws {
+        let context = AnkiNoteContext(
+            term: makeTerm(term: "猫", reading: "ねこ"), sentence: "A&B=C+D", source: nil
+        )
+        let url = try #require(makeExport(fields: [.word: "Word", .sentence: "Sentence"])
+            .addNoteURL(context: context, callback: "riidaa://anki-callback?term=42"))
+
+        #expect(exportedFields(url)["Sentence"] == "A&B=C+D")
+        #expect(exportedFields(url).count == 2)
+        let items = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
+        #expect(items.first { $0.name == "x-success" }?.value == "riidaa://anki-callback?term=42")
+    }
+
+    /// The bolded word is the inflected form the parser matched, at its exact offset — and a
+    /// match that doesn't land there must leave the sentence alone.
+    @Test func boldsTheLookedUpWord() throws {
+        func sentence(_ match: SentenceMatch?, in text: String) throws -> String? {
+            let context = AnkiNoteContext(
+                term: makeTerm(term: "思う", reading: "おもう"), sentence: text, source: nil, match: match
+            )
+            let url = try #require(makeExport(fields: [.sentence: "Sentence"])
+                .addNoteURL(context: context, callback: "x"))
+            return exportedFields(url)["Sentence"]
+        }
+
+        #expect(try sentence(SentenceMatch(surface: "思っている", offset: 8), in: "君は学校を何だと思っているのかね")
+            == "君は学校を何だと<b>思っている</b>のかね")
+        // The second occurrence, not the first.
+        #expect(try sentence(SentenceMatch(surface: "猫", offset: 2), in: "猫と猫") == "猫と<b>猫</b>")
+
+        for bad in [SentenceMatch(surface: "犬", offset: 0), SentenceMatch(surface: "猫", offset: 99)] {
+            #expect(try sentence(bad, in: "猫がいる") == "猫がいる")
+        }
+    }
+
+    /// Alias order is what puts the sentence in `Sentence` rather than Lapis's `SelectionText`,
+    /// and no two tokens may claim the same field.
+    @Test func mapsRealNoteTypesAutomatically() {
+        let lapis = ["Expression", "ExpressionFurigana", "ExpressionReading", "ExpressionAudio",
+                     "SelectionText", "MainDefinition", "DefinitionPicture", "Sentence",
+                     "SentenceFurigana", "SentenceAudio", "Picture", "Glossary", "Hint",
+                     "PitchPosition", "PitchCategories", "Frequency", "FreqSort", "MiscInfo"]
+        let mapped = AnkiFieldToken.suggestedMapping(for: lapis)
+        #expect(mapped[.word] == "Expression")
+        #expect(mapped[.sentence] == "Sentence")
+        #expect(mapped[.furigana] == "ExpressionFurigana")
+        #expect(mapped[.audio] == "ExpressionAudio")
+        #expect(mapped[.picture] == "Picture")
+        #expect(mapped[.pitch] == "PitchPosition")
+        #expect(mapped[.frequency] == "Frequency")
+        #expect(mapped[.source] == "MiscInfo")
+        #expect(Set(mapped.values).count == mapped.count)
+
+        let kaishi = AnkiFieldToken.suggestedMapping(
+            for: ["Word", "Word Reading", "Word Meaning", "Word Furigana", "Word Audio",
+                  "Sentence", "Notes", "Pitch Accent", "Frequency", "Picture"]
+        )
+        #expect(kaishi[.word] == "Word")
+        #expect(kaishi[.meaning] == "Word Meaning")
+        #expect(kaishi[.pitch] == "Pitch Accent")
+        #expect(kaishi[.source] == "Notes")
+
+        #expect(AnkiFieldToken.suggestedMapping(for: ["Champ1", "Zzz"]).isEmpty)
+    }
+
+    /// Switching note type used to carry the previous one's field names across, producing
+    /// "field MiscInfo does not exist" on export.
+    @Test func dropsMappingsTheNoteTypeDoesNotHave() {
+        let settings = SettingsModel()
+        let lapis = AnkiInfo.NoteType(name: "Lapis", kind: "normal",
+            fields: [.init(name: "Expression"), .init(name: "MiscInfo"), .init(name: "Sentence")])
+        let kaishi = AnkiInfo.NoteType(name: "Kaishi", kind: "normal",
+            fields: [.init(name: "Word"), .init(name: "Sentence"), .init(name: "Notes")])
+
+        settings.ankiNoteType = lapis
+        settings.autoMapAnkiFields(for: lapis)
+        #expect(settings.ankiFields["source"] == "MiscInfo")
+
+        settings.ankiNoteType = kaishi
+        #expect(settings.ankiFields["source"] == nil)
+        #expect(settings.ankiFields["sentence"] == "Sentence")
+
+        settings.autoMapAnkiFields(for: kaishi)
+        #expect(settings.ankiFields["word"] == "Word")
+        #expect(settings.ankiFields["source"] == "Notes")
+    }
+
+}

--- a/riidaaTests/FuriganaTests.swift
+++ b/riidaaTests/FuriganaTests.swift
@@ -1,0 +1,39 @@
+//
+//  FuriganaTests.swift
+//  riidaaTests
+//
+
+import Testing
+import riidaa
+
+struct FuriganaTests {
+
+    @Test func annotatesKanjiAndOkurigana() {
+        #expect(Furigana.annotate(term: "番地", reading: "ばんち") == "番地[ばんち]")
+        #expect(Furigana.annotate(term: "人々", reading: "ひとびと") == "人々[ひとびと]")
+        #expect(Furigana.annotate(term: "思う", reading: "おもう") == "思[おも]う")
+        #expect(Furigana.annotate(term: "気持ち", reading: "きもち") == "気持[きも]ち")
+        #expect(Furigana.annotate(term: "勉強する", reading: "べんきょうする") == "勉強[べんきょう]する")
+    }
+
+    /// Anki reads a group's base back to the previous space, and interior kana have to keep
+    /// their place rather than being swallowed into one group.
+    @Test func spacesGroupsAndDistributesAroundInteriorKana() {
+        #expect(Furigana.annotate(term: "お茶", reading: "おちゃ") == "お 茶[ちゃ]")
+        #expect(Furigana.annotate(term: "お兄さん", reading: "おにいさん") == "お 兄[にい]さん")
+        #expect(Furigana.annotate(term: "引っ越し", reading: "ひっこし") == "引[ひ]っ 越[こ]し")
+        #expect(Furigana.annotate(term: "見た目", reading: "みため") == "見[み]た 目[め]")
+        #expect(Furigana.annotate(term: "持ち込む", reading: "もちこむ") == "持[も]ち 込[こ]む")
+        #expect(Furigana.annotate(term: "立ち上がる", reading: "たちあがる") == "立[た]ち 上[あ]がる")
+    }
+
+    /// ヶ reads か, so the kana can't be anchored; one coarse group is still valid furigana.
+    @Test func handlesReadingsThatDoNotLineUp() {
+        #expect(Furigana.annotate(term: "ヶ月", reading: "かげつ") == "ヶ月[かげつ]")
+        #expect(Furigana.annotate(term: "コーヒー", reading: "こーひー") == "コーヒー[こーひー]")
+        #expect(Furigana.annotate(term: "ある", reading: "ある") == "ある")
+        #expect(Furigana.annotate(term: "猫", reading: "") == "猫")
+        #expect(Furigana.annotate(term: "", reading: "ねこ") == nil)
+    }
+
+}

--- a/riidaaTests/PageImageServerTests.swift
+++ b/riidaaTests/PageImageServerTests.swift
@@ -1,0 +1,61 @@
+//
+//  PageImageServerTests.swift
+//  riidaaTests
+//
+
+import Foundation
+import UIKit
+import Testing
+@testable import riidaa
+
+/// Serialised: every case drives the one shared listener.
+@Suite(.serialized)
+struct PageImageServerTests {
+
+    private var session: URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 8
+        return URLSession(configuration: config)
+    }
+
+    /// Scale 1 so pixel dimensions match the requested size, whatever the simulator's scale.
+    private func makeImage(width: CGFloat = 60, height: CGFloat = 90) -> UIImage {
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = 1
+        return UIGraphicsImageRenderer(size: CGSize(width: width, height: height), format: format).image { context in
+            UIColor.systemIndigo.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        }
+    }
+
+    @Test func servesThePublishedImageOverLoopback() async throws {
+        defer { PageImageServer.shared.stop() }
+
+        let url = try #require(await PageImageServer.shared.publish(makeImage()))
+        #expect(url.host == "127.0.0.1")
+
+        let (data, response) = try await session.data(from: url)
+        #expect((response as? HTTPURLResponse)?.statusCode == 200)
+        let decoded = try #require(UIImage(data: data))
+        #expect(decoded.size == CGSize(width: 60, height: 90))
+    }
+
+    /// Only the published path is served, and stopping must release the port so a later export
+    /// can't be handed the previous page.
+    @Test func servesNothingElseAndReleasesThePortOnStop() async throws {
+        let url = try #require(await PageImageServer.shared.publish(makeImage()))
+        let other = try #require(URL(string: "http://127.0.0.1:\(url.port ?? 0)/other.jpg"))
+
+        let (_, response) = try await session.data(from: other)
+        #expect((response as? HTTPURLResponse)?.statusCode == 404)
+
+        PageImageServer.shared.stop()
+        do {
+            _ = try await session.data(from: url)
+            Issue.record("still serving after stop()")
+        } catch {
+            // Expected: connection refused.
+        }
+    }
+
+}

--- a/riidaaTests/TermMetaStorageTests.swift
+++ b/riidaaTests/TermMetaStorageTests.swift
@@ -1,0 +1,120 @@
+//
+//  TermMetaStorageTests.swift
+//  riidaaTests
+//
+
+import Foundation
+import Testing
+@testable import riidaa
+
+/// Exercises the real SQLite layer on the test host. Serialised because every case drives the
+/// shared connection and the shared dictionary list.
+@MainActor
+@Suite(.serialized)
+struct TermMetaStorageTests {
+
+    private func makeDictionary(_ title: String) -> DictionaryDB? {
+        let dictionary = SQLiteManager.shared.insertDictionary(
+            revision: "test", title: title, sequenced: false, format: 3,
+            author: nil, isUpdatable: false, indexUrl: nil, downloadUrl: nil, url: nil,
+            description: nil, attribution: nil, sourceLanguage: nil, targetLanguage: nil,
+            frequencyMode: nil
+        )
+        if let dictionary = dictionary {
+            AppManager.shared.dictionaries.append(dictionary)
+        }
+        return dictionary
+    }
+
+    private func forget(_ dictionary: DictionaryDB) {
+        try? SQLiteManager.shared.deleteDictionary(dictionaryId: dictionary.id)
+        AppManager.shared.dictionaries.removeAll { $0.id == dictionary.id }
+        SQLiteManager.shared.purgeOrphanedEntries()
+    }
+
+    private func blob(_ raw: String) -> Data { raw.data(using: .utf8)! }
+
+    private func remaining(_ dictionary: DictionaryDB) -> Int {
+        let db = SQLiteManager.shared.getDatabase()!
+        let raw = try? db.scalar("SELECT count(*) FROM term_meta WHERE dictionaryId = ?", dictionary.id)
+        return (raw as? Int64).map(Int.init) ?? -1
+    }
+
+    @Test func storesAndReadsBackBothMetadataKinds() throws {
+        guard let dictionary = makeDictionary("RoundTrip") else { Issue.record("no dictionary"); return }
+        defer { forget(dictionary) }
+
+        #expect(SQLiteManager.shared.insertTermMeta(metaInsert: [
+            TermMetaInsertion(term: "夫妻", reading: "ふさい", mode: "freq",
+                              data: blob(#"{"reading":"ふさい","frequency":{"value":6923,"displayValue":"6923"}}"#),
+                              dictionaryId: dictionary.id),
+            TermMetaInsertion(term: "夫妻", reading: "ふさい", mode: "pitch",
+                              data: blob(#"{"reading":"ふさい","pitches":[{"position":1}]}"#),
+                              dictionaryId: dictionary.id),
+            TermMetaInsertion(term: "夫妻", reading: "ふうさい", mode: "freq",
+                              data: blob(#"{"reading":"ふうさい","frequency":1}"#),
+                              dictionaryId: dictionary.id),
+        ]) != nil)
+
+        let found = SQLiteManager.shared.findTermMeta(texts: ["夫妻"]).filter { $0.dictionary.id == dictionary.id }
+        #expect(found.count == 3)
+
+        // The entry for the other reading is filtered out.
+        let summary = TermMetaSummary(meta: found, reading: "ふさい")
+        #expect(summary.frequencyLabels == ["RoundTrip: 6923"])
+        #expect(summary.pitchPositions == ["[1]"])
+    }
+
+    /// Wadoku ships 10,000 entries per bank, which is 50,000 bind parameters against SQLite's
+    /// 32,766 limit — the import failed outright until the inserts were chunked.
+    @Test func insertsABankLargerThanTheBindParameterLimit() throws {
+        guard let dictionary = makeDictionary("BigBank") else { Issue.record("no dictionary"); return }
+        defer { forget(dictionary) }
+
+        let rows = (0..<10_000).map { index in
+            TermMetaInsertion(term: "語\(index)", reading: "", mode: "freq",
+                              data: blob(#"{"value":1,"displayValue":"1"}"#),
+                              dictionaryId: dictionary.id)
+        }
+        #expect(SQLiteManager.shared.insertTermMeta(metaInsert: rows) != nil)
+
+        for index in [0, 5_000, 9_999] {
+            let found = SQLiteManager.shared.findTermMeta(texts: ["語\(index)"])
+                .filter { $0.dictionary.id == dictionary.id }
+            #expect(found.count == 1, "語\(index) missing after a large insert")
+        }
+    }
+
+    /// Deleting removes the dictionary at once and clears its entries afterwards, resuming from
+    /// whatever is still orphaned — so being interrupted strands nothing.
+    @Test func purgesDeletedEntriesAndResumesIfInterrupted() throws {
+        guard let dictionary = makeDictionary("PurgeMe") else { Issue.record("no dictionary"); return }
+        SQLiteManager.shared.purgeOrphanedEntries()
+
+        let rows = (0..<400).map { index in
+            TermMetaInsertion(term: "purge\(index)", reading: "", mode: "freq",
+                              data: blob(#"{"value":1,"displayValue":"1"}"#),
+                              dictionaryId: dictionary.id)
+        }
+        #expect(SQLiteManager.shared.insertTermMeta(metaInsert: rows) != nil)
+
+        try SQLiteManager.shared.deleteDictionary(dictionaryId: dictionary.id)
+        AppManager.shared.dictionaries.removeAll { $0.id == dictionary.id }
+
+        // Invisible immediately, even though the rows are still on disk.
+        #expect(SQLiteManager.shared.findTermMeta(texts: ["purge0"]).isEmpty)
+        #expect(remaining(dictionary) == 400)
+
+        var batchesAllowed = 2
+        SQLiteManager.shared.purgeOrphanedEntries(batchSize: 50) {
+            defer { batchesAllowed -= 1 }
+            return batchesAllowed > 0
+        }
+        let afterInterruption = remaining(dictionary)
+        #expect(afterInterruption < 400 && afterInterruption > 0)
+
+        SQLiteManager.shared.purgeOrphanedEntries(batchSize: 50)
+        #expect(remaining(dictionary) == 0)
+    }
+
+}

--- a/riidaaTests/TermMetaTests.swift
+++ b/riidaaTests/TermMetaTests.swift
@@ -1,0 +1,79 @@
+//
+//  TermMetaTests.swift
+//  riidaaTests
+//
+
+import Foundation
+import Testing
+@testable import riidaa
+
+struct TermMetaTests {
+
+    private func json(_ raw: String) -> Any {
+        try! JSONSerialization.jsonObject(with: raw.data(using: .utf8)!, options: [.fragmentsAllowed])
+    }
+
+    private func dictionary(_ title: String) -> DictionaryDB {
+        DictionaryDB(id: 1, revision: "", title: title, format: 3)
+    }
+
+    /// Both shapes JPDB ships: a bare rating for kana entries and a reading-scoped one for
+    /// words written in kanji. The spec also allows a plain number or string.
+    @Test func parsesTheFrequencyShapesRealDictionariesUse() throws {
+        let bare = try #require(TermMetaParser.parse(mode: "freq", data: json(#"{"value": 1, "displayValue": "1㋕"}"#)))
+        #expect(bare.reading == "")
+        guard case .frequency(let a) = bare.content else { Issue.record("not a frequency"); return }
+        #expect(a.value == 1 && a.display == "1㋕")
+
+        let scoped = try #require(TermMetaParser.parse(
+            mode: "freq", data: json(#"{"reading": "おもう", "frequency": {"value": 20, "displayValue": "20"}}"#)
+        ))
+        #expect(scoped.reading == "おもう")
+
+        let number = try #require(TermMetaParser.parse(mode: "freq", data: json("1234")))
+        guard case .frequency(let b) = number.content else { Issue.record("not a frequency"); return }
+        #expect(b.value == 1234)
+
+        #expect(TermMetaParser.parse(mode: "ipa", data: json(#"{"reading":"x"}"#)) == nil)
+        #expect(TermMetaParser.parse(mode: "freq", data: json(#"{"nonsense": true}"#)) == nil)
+    }
+
+    @Test func parsesPitchWithDevoicing() throws {
+        let parsed = try #require(TermMetaParser.parse(
+            mode: "pitch", data: json(#"{"reading": "しんぴ", "pitches": [{"position": 1, "devoice": [2]}]}"#)
+        ))
+        #expect(parsed.reading == "しんぴ")
+        guard case .pitch(let accents) = parsed.content else { Issue.record("not a pitch"); return }
+        #expect(accents == [PitchAccent(position: 1, devoice: [2])])
+    }
+
+    @Test func namesThePitchPatternFromTheMoraCount() {
+        #expect(PitchAccent(position: 0, devoice: []).category(moraCount: 4) == "heiban")
+        #expect(PitchAccent(position: 1, devoice: []).category(moraCount: 4) == "atamadaka")
+        #expect(PitchAccent(position: 2, devoice: []).category(moraCount: 4) == "nakadaka")
+        #expect(PitchAccent(position: 4, devoice: []).category(moraCount: 4) == "odaka")
+
+        #expect(PitchAccent.moraCount(of: "きょう") == 2)
+        #expect(PitchAccent.moraCount(of: "がっこう") == 4)
+    }
+
+    /// 夫妻 carries two ratings under one reading in JPDB, so neither may be collapsed — but a
+    /// rating filed under both the term and its reading comes back twice and must be.
+    @Test func summarisesWithoutLosingOrDuplicatingRatings() {
+        let meta = [
+            TermMetaDB(term: "夫妻", reading: "ふさい", dictionary: dictionary("JPDB"),
+                       content: .frequency(TermFrequency(value: 6923, display: "6923"))),
+            TermMetaDB(term: "夫妻", reading: "ふさい", dictionary: dictionary("JPDB"),
+                       content: .frequency(TermFrequency(value: 55898, display: "55898㋕"))),
+            TermMetaDB(term: "夫妻", reading: "ふさい", dictionary: dictionary("JPDB"),
+                       content: .frequency(TermFrequency(value: 6923, display: "6923"))),
+            TermMetaDB(term: "夫妻", reading: "ふうさい", dictionary: dictionary("JPDB"),
+                       content: .frequency(TermFrequency(value: 1, display: "1"))),
+        ]
+        let summary = TermMetaSummary(meta: meta, reading: "ふさい")
+        #expect(summary.frequencyLabels == ["JPDB: 6923", "JPDB: 55898㋕"])
+        #expect(summary.frequencySortValue == 6923)
+        #expect(TermMetaSummary(meta: [], reading: "ねこ").isEmpty)
+    }
+
+}

--- a/riidaaTests/WordAudioTests.swift
+++ b/riidaaTests/WordAudioTests.swift
@@ -1,0 +1,45 @@
+//
+//  WordAudioTests.swift
+//  riidaaTests
+//
+
+import Foundation
+import Testing
+@testable import riidaa
+
+struct WordAudioTests {
+
+    private func query(_ url: URL) -> [String: String] {
+        var items: [String: String] = [:]
+        for item in URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? [] {
+            items[item.name] = item.value
+        }
+        return items
+    }
+
+    @Test func buildsTheEndpointUrl() throws {
+        let url = try #require(WordAudio.url(term: "夫妻", reading: "ふさい"))
+        let items = query(url)
+        #expect(items["kanji"] == "夫妻")
+        #expect(items["kana"] == "ふさい")
+        // Without a media extension AnkiMobile won't download it at all.
+        #expect(items["fakePath"]?.hasSuffix(".mp3") == true)
+
+        let kanaOnly = try #require(WordAudio.url(term: "", reading: "ねこ"))
+        #expect(query(kanaOnly)["kanji"] == "ねこ")
+
+        #expect(WordAudio.url(term: " ", reading: "") == nil)
+    }
+
+    /// A real recording redirects to a CDN copy; a miss serves a fixed "not found" clip from
+    /// the requested URL, so a changed URL is the whole signal.
+    @Test func recognisesARealRecordingByItsRedirect() throws {
+        let requested = try #require(WordAudio.url(term: "猫", reading: "ねこ"))
+        let cdn = try #require(URL(string: "https://cdn.innovativelanguage.com/a/93487.mp3"))
+
+        #expect(WordAudio.isRecording(requested: requested, resolved: cdn))
+        #expect(!WordAudio.isRecording(requested: requested, resolved: requested))
+        #expect(!WordAudio.isRecording(requested: requested, resolved: nil))
+    }
+
+}


### PR DESCRIPTION
# Description

> **Depends on #7** (dictionary import).

This reworks the Anki export so fields are mapped rather than hardcoded, and adds the values that mapping makes possible.

Right now the export fills four fields through four separate blocks in `MangaReaderParserView`, with matching pickers in `AnkiView`, so adding a field means a change in both. This inverts it: a list of values リーダー can offer, which the user maps to fields of their note type. Both settings and export loop over that one list, so a new value is a single enum case. Existing users' four settings migrate across automatically.

`word` · `reading` · `furigana` · `audio` · `picture` · `pitch` · `pitchCategories` · `frequency` · `frequencySort` · `meaning` · `glossary` · `sentence` · `source`

**The new values**
- **furigana** - derived from term and reading
- **sentence** - bolds the word at the position the parser matched
- **source** - manga title, volume and page
- **glossary** - the full definition list
- **audio** - JapanesePod101, as Yomitan uses by default
- **picture** - the current manga page, see below
- **pitch / frequency** - from the dictionaries in #7

**Page image**
AnkiMobile only accepts media as a URL it downloads itself, and a manga page exists nowhere but the device. So `PageImageServer` publishes it briefly on `127.0.0.1` at a random path, and stops once Anki confirms the note. Nothing leaves the device and it works in aeroplane mode.

**Also included**
- "Match fields automatically" maps a note type by field name - exact matches only, so an unfamiliar note type maps nothing rather than misfiling
- Export button is hidden until a deck and note type are chosen

**Reader**
- The lookup panel is now a sheet with detents; its custom drag gesture competed with the token strip and results list. Background interaction stays on up to the medium detent, so another text box can still be tapped.
- Swiping past the edge of a zoomed page turns the page instead of stopping at the pan limit.


**Example Card**
<img width="582" height="1006" alt="IMG_6369" src="https://github.com/user-attachments/assets/bec04300-1133-4959-a3b8-07eb4f819e7e" />

